### PR TITLE
Support for extract-text plugin bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,13 +47,22 @@ Plugin.prototype.writeOutput = function(compiler, hashes, outputFull) {
 Plugin.prototype.getHashes = function(compiler) {
 	var webpackStatsJson = compiler.getStats().toJson();
 	var assets = {};
+	var filterDevChunks = function(value) {
+		return !(
+			/source-?map/.test(compiler.options.devtool) &&
+			/\.map$/.test(value)
+		);
+	};
+
 	for (var chunk in webpackStatsJson.assetsByChunkName) {
 		var chunkValue = webpackStatsJson.assetsByChunkName[chunk];
 
-		// Webpack outputs an array for each chunk when using sourcemaps
+		// Webpack outputs an array for each chunk when using sourcemaps and some plugins
 		if (chunkValue instanceof Array) {
-			// Is the main bundle always the first element?
-			chunkValue = chunkValue[0];
+			// When using plugins like 'extract-text', for extracting CSS from JS, webpack
+			// will push the new bundle to the array, so the last item will be the correct
+			// chunk
+			chunkValue = chunkValue.filter(filterDevChunks).pop();
 		}
 
 		if (compiler.options.output.publicPath) {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
   },
   "homepage": "https://github.com/sporto/assets-webpack-plugin",
   "devDependencies": {
+    "css-loader": "^0.9.1",
+    "extract-text-webpack-plugin": "^0.3.8",
     "jasmine-node": "^1.14.5",
     "jshint": "^2.5.2",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.2.8",
+    "style-loader": "^0.8.3",
     "webpack": "^1.3.3-beta1"
   }
 }

--- a/spec/fixtures/styles.js
+++ b/spec/fixtures/styles.js
@@ -1,0 +1,1 @@
+require('./stylesheet.css');

--- a/spec/fixtures/stylesheet.css
+++ b/spec/fixtures/stylesheet.css
@@ -1,0 +1,1 @@
+.test { color: red; }

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var rm_rf = require('rimraf');
 var mkdirp = require('mkdirp');
 var Plugin = require('../index.js');
@@ -149,6 +150,36 @@ describe('Plugin', function() {
 		};
 
 		var expected = [/{"main":"index-bundle-[0-9a-f]+\.js"}/];
+
+		testPlugin(webpackConfig, expected, null, done);
+	});
+
+	it('works with ExtractTextPlugin for stylesheets', function(done) {
+
+		var webpackConfig = {
+			entry: {
+				one: path.join(__dirname, 'fixtures/one.js'),
+				two: path.join(__dirname, 'fixtures/two.js'),
+				styles: path.join(__dirname, 'fixtures/styles.js')
+			},
+			output: {
+				path: OUTPUT_DIR,
+				filename: '[name]-bundle.js'
+			},
+			module: {
+				loaders: [
+					{test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader')}
+				]
+			},
+			plugins: [
+				new ExtractTextPlugin('[name]-bundle.css', {allChunks: true}),
+				new Plugin({
+					path: 'dist'
+				})
+			]
+		};
+
+		var expected = ['{"one":"one-bundle.js","two":"two-bundle.js","styles":"styles-bundle.css"}'];
 
 		testPlugin(webpackConfig, expected, null, done);
 	});


### PR DESCRIPTION
Webpack docs [describes](http://webpack.github.io/docs/stylesheets.html) the use of **ExtractTextPlugin** to embed stylesheets to JS bundles, and it also guides the generation of a separated CSS bundle. This plugin is really useful to generate the manifest of the bundled assets but it is creating an invalid version when ExtractTextPlugin is configured to generate a separated bundle.

With the version 0.1.0, the following configuration will generate a **.js** value instead of **.css**:

``` js
{
  entry: {
    app: './src/app.js',
    styles: './src/styles.js'
  },
  module: {
    loaders: [
      {test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader')}
    ]
  },
  output: {
    filename: 'app-bundle.js'
  },
  plugins: [
    new ExtractTextPlugin('app-bundle.css', {allChunks: true})
  ]
}
```

output:

``` js
{"app":"app-bundle.js", "styles":"app-bundle.js"} // it should be: "styles":"app-bundle.css"
```

I did a small change to consider the last value (the most updated bundle) when chunk value is an array and deal with the exceptions when devtool is used. I believe this will be useful for everybody but I do understand if you want to keep the manifest just for JS files.

This pull request includes the "fix" and the tests for this use case, thanks.
