### PR TITLE
better getAssetChunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,9 @@ Plugin.getAssetChunk = function (stringOrArray, compilerOptions) {
 		.replace('[file]', '')
 		.replace('[query]', '')
 		.replace('[hash]', '')
-		.replace('.', '');
-	var mapRegex = new RegExp(mapSegment);
+		.replace('.', '\\.')
+		.replace(/\//, '\\/.*');
+	var mapRegex = new RegExp(mapSegment + '$');
 
 	function isSourceMap(value) {
 		return mapRegex.test(value);


### PR DESCRIPTION
can't find the right filename when sourceMapFilename contains directory(eg: ‘maps/[file].map’) or the entry's name contains 'map'.
