### PR TITLE
Prepend publicPath to asset path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,10 +79,6 @@ Plugin.prototype.buildOutput = function(compiler) {
 
 		var chunkMap = Plugin.getChunkMap(compiler.options, chunkValue);
 
-		// if (compiler.options.output.publicPath) {
-		// 	chunkMap = compiler.options.output.publicPath + chunkMap;
-		// }
-
 		output[chunkName] = chunkMap;
 	}
 
@@ -167,6 +163,7 @@ Plugin.getChunkMap = function (compilerOptions, stringOrArray) {
 		return !isSourceMap(value);
 	}
 	var output = {};
+	var publicPath = compilerOptions.output.publicPath || '';
 
 	if (stringOrArray instanceof Array) {
 		// When using plugins like 'extract-text', for extracting CSS from JS, webpack
@@ -177,10 +174,10 @@ Plugin.getChunkMap = function (compilerOptions, stringOrArray) {
 		for (var a = 0; a < stringOrArray.length ; a++) {
 			var asset = stringOrArray[a];
 			var kind = Plugin.getAssetKind(compilerOptions, asset);
-			output[kind] = asset;
+			output[kind] = publicPath + asset;
 		}
 	} else {
-		output.js = stringOrArray;
+		output.js = publicPath + stringOrArray;
 	}
 
 	return output;

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -331,5 +331,34 @@ describe('Plugin', function() {
 		expectOutput(args, done);
 	});
 
+	it('includes full publicPath', function(done) {
+
+		var webpackConfig = {
+			devtool: 'sourcemap',
+			entry: path.join(__dirname, 'fixtures/one.js'),
+			output: {
+				path: OUTPUT_DIR,
+				publicPath: '/public/path/',
+				filename: 'index-bundle.js'
+			},
+			plugins: [new Plugin({
+				path: 'dist'
+			})]
+		};
+
+		var expected = {
+			main: {
+				js:    '/public/path/index-bundle.js',
+				jsMap: '/public/path/index-bundle.js.map'
+			}
+		};
+
+		var args = {
+			config: webpackConfig,
+			expected: expected
+		};
+
+		expectOutput(args, done);
+	});
 
 });


### PR DESCRIPTION
Fixes https://github.com/sporto/assets-webpack-plugin/issues/10.
