### PR TITLE
Now making sure that output folder exists. Fixes #12

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var mkdirp = require('mkdirp');
 
 // function extend(target, source) {
 // 	for(var k in source){
@@ -22,10 +23,12 @@ Plugin.prototype.apply = function(compiler) {
 		var outputDir = _this.options.path || '.';
 
 		try {
-			// check that output folder exists
-			fs.lstatSync(outputDir).isDirectory();
+			// make sure output folder exists
+			mkdirp.sync(outputDir);
 		} catch (e) {
-			compiler.errors.push(new Error('Plugin: Folder not found ' + outputDir));
+			compiler.errors.push(new Error(
+				'Assets Plugin: Could not create output folder' + outputDir
+			));
 			return callback();
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assets-webpack-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Emits a json file with assets paths",
   "main": "index.js",
   "scripts": {
@@ -29,10 +29,12 @@
     "extract-text-webpack-plugin": "^0.3.8",
     "jshint": "^2.5.2",
     "lodash": "^3.9.3",
-    "mkdirp": "^0.5.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.2.8",
     "style-loader": "^0.8.3",
     "webpack": "^1.3.3-beta1"
+  },
+  "dependencies": {
+    "mkdirp": "^0.5.1"
   }
 }

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -144,25 +144,6 @@ describe('Plugin', function() {
 		expectOutput(args, done);
 	});
 
-	it('registers a webpack error when output folder doesnt exists', function(done) {
-		var webpackConfig = {
-			entry: path.join(__dirname, 'fixtures/one.js'),
-			output: {
-				path: OUTPUT_DIR,
-				filename: 'index-bundle.js'
-			},
-			plugins: [new Plugin({
-				path: 'notFound'
-			})]
-		};
-
-		webpack(webpackConfig, function(err, stats) {
-			expect(stats.hasErrors()).to.be.true;
-			expect(stats.toJson().errors[0]).to.contain('Plugin');
-			done();
-		});
-	});
-
 	it('works with source maps', function(done) {
 
 		var webpackConfig = {


### PR DESCRIPTION
I'm using this plugin to output assets to the same folder where my bundle is and that folder doesn't exists until bundling finishes so always results in an error. To mitigate this I replaced `outputDir` check with `mkdirp`.
