### PR TITLE
Skip sourcemaps and support multi-compiler mode

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+tmp/
+test/fixtures/

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 
 var getAssetKind = require('./lib/getAssetKind');
 var isHMRUpdate = require('./lib/isHMRUpdate');
+var isSourceMap = require('./lib/isSourceMap');
 
 
 function AssetsWebpackPlugin (options) {
@@ -59,7 +60,7 @@ AssetsWebpackPlugin.prototype = {
                     assets = [assets];
                 }
                 chunkMap[chunkName] = assets.reduce(function (typeMap, asset) {
-                    if (isHMRUpdate(options, asset)) {
+                    if (isHMRUpdate(options, asset) || isSourceMap(options, asset)) {
                         return typeMap;
                     }
 

--- a/lib/getAssetKind.js
+++ b/lib/getAssetKind.js
@@ -1,17 +1,9 @@
 var camelcase = require('camelcase');
 
-var isSourceMap = require('./isSourceMap');
 var getFileExtension = require('./getFileExtension');
 
 
 module.exports = function getAssetKind (options, asset) {
-    var isMap = isSourceMap(options, asset);
-    if (isMap) {
-        asset = asset.replace(/\.(?:source[ _.-]?)?map/i, '');
-    }
     var ext = getFileExtension(asset);
-    if (isMap) {
-        ext += 'SourceMap';
-    }
     return camelcase(ext);
 };

--- a/lib/getFileExtension.js
+++ b/lib/getFileExtension.js
@@ -5,4 +5,4 @@ module.exports = function getFileExtension (asset) {
     var url = URL.parse(asset);
     var ext = path.extname(url.pathname);
     return ext ? ext.slice(1) : '';
-}
+};

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -1,0 +1,51 @@
+var mkdirp = require('mkdirp');
+var path = require('path');
+var fs = require('fs');
+var merge = require('lodash.merge');
+
+var error = require('../utils/error');
+
+
+module.exports = function (options) {
+    var outputPath = path.join(options.path, options.filename);
+    var update = options.update;
+    var firstRun = true;
+
+    return function writeOutput (newAssets, next) {
+        // if potions.update is false and we're on the first pass of a (possibly) multicompiler
+        var overwrite = !update && firstRun;
+
+        mkdirp(options.path, function (err) {
+            if (err) {
+                return next(error('Could not create output folder ' + options.path, err));
+            }
+            fs.readFile(outputPath, 'utf8', function (err, data) {
+                // if file does not exist, just write data to it
+                if (err && err.code !== 'ENOENT') {
+                    return next(error('Could not read output file ' + outputPath, err));
+                }
+                // if options.update is false and we're on first run,
+                // start with empty data
+                data = overwrite ? '{}' : data || '{}';
+
+                var oldAssets;
+                try {
+                    oldAssets = JSON.parse(data);
+                } catch (err) {
+                    oldAssets = {};
+                }
+
+                var assets = merge({}, oldAssets, newAssets);
+                var output = JSON.stringify(assets, null, options.prettyPrint ? 2 : null);
+
+                fs.writeFile(outputPath, output, function (err) {
+                    if (err) {
+                        return next(error('Unable to write to ' + outputPath, err));
+                    }
+                    firstRun = false;
+                    next();
+                });
+            });
+        });
+    };
+};

--- a/lib/output/createQueuedWriter.js
+++ b/lib/output/createQueuedWriter.js
@@ -1,0 +1,33 @@
+
+/**
+ * Takes in a processor function, and returns a writer function.
+ *
+ * @param {Function} processor
+ *
+ * @return {Function} queuedWriter
+ */
+module.exports = function createQueuedWriter (processor) {
+    var queue = [];
+
+    var iterator = function (callback) {
+        return function (err) {
+            queue.shift();
+            callback(err);
+
+            var next = queue[0];
+            if (next) {
+                processor(next.data, iterator(next.callback));
+            }
+        };
+    };
+
+    return function queuedWriter (data, callback) {
+        var empty = !queue.length;
+        queue.push({data: data, callback: callback});
+
+        if (empty) {
+            // start processing
+            processor(data, iterator(callback));
+        }
+    };
+};

--- a/lib/pathTemplate.js
+++ b/lib/pathTemplate.js
@@ -13,7 +13,7 @@ module.exports = function createTemplate (str) {
     }
 
     return template_cache[str] = new PathTemplate(str);
-}
+};
 
 
 function PathTemplate (template) {
@@ -43,14 +43,15 @@ PathTemplate.prototype = {
     resolve: function (data) {
         return this.fields.reduce(function (output, field) {
             var replacement = '',
-                placeholder = field.placeholder
-            ;
+                placeholder = field.placeholder,
+                width = field.width;
+
             if (field.prefix) {
                 output += field.prefix;
             }
             if (placeholder) {
                 replacement = data[placeholder] || '';
-                if (field.width && (placeholder === 'hash' || placeholder === 'chunkhash')) {
+                if (width && (placeholder === 'hash' || placeholder === 'chunkhash')) {
                     replacement = replacement.slice(0, width);
                 }
                 output += replacement;
@@ -68,7 +69,7 @@ PathTemplate.prototype = {
  *     placeholder: 'replacement field name'
  *     [, width: maximum hash length for hash & chunkhash placeholders]
  * }
- * 
+ *
  * The values in the object conceptually represent a span of literal text followed by a single replacement field.
  * If there is no literal text (which can happen if two replacement fields occur consecutively),
  * then prefix will be an empty string.
@@ -79,10 +80,10 @@ PathTemplate.prototype = {
 function parseTemplate (str) {
     var fields = [];
     var char = '', pos = 0;
-    var prefix = '', placeholder;
+    var prefix = '';
     var match = null, input;
 
-    while (true) {
+    while (true) { // eslint-disable-line no-constant-condition
         char = str[pos];
 
         if (!char) {
@@ -93,7 +94,7 @@ function parseTemplate (str) {
             break;
         } else if (char === '[') {
 
-            input = str.slice(pos)
+            input = str.slice(pos);
             match = SIMPLE_PLACEHOLDER_RX.exec(input);
             if (match) {
                 fields.push({
@@ -140,22 +141,22 @@ function createTemplateMatcher (fields) {
         }
         if (field.placeholder) {
             switch (field.placeholder) {
-                case 'id':
-                    pattern += '\\d+';
-                    break;
-                case 'hash':
-                case 'chunkhash':
-                    pattern += '[0-9a-fA-F]';
-                    pattern += field.width ? '{1,' + field.width + '}' : '+';
-                    break;
-                case 'name':
-                case 'file':
-                case 'filebase':
-                    pattern += '.+?';
-                    break;
-                case 'query':
-                    pattern += '(?:\\?.+?)?';
-                    break;
+            case 'id':
+                pattern += '\\d+';
+                break;
+            case 'hash':
+            case 'chunkhash':
+                pattern += '[0-9a-fA-F]';
+                pattern += field.width ? '{1,' + field.width + '}' : '+';
+                break;
+            case 'name':
+            case 'file':
+            case 'filebase':
+                pattern += '.+?';
+                break;
+            case 'query':
+                pattern += '(?:\\?.+?)?';
+                break;
             }
         }
         if (i === length - 1) {

--- a/lib/utils/error.js
+++ b/lib/utils/error.js
@@ -1,0 +1,7 @@
+var assign = require('lodash.assign');
+
+module.exports = function pluginError (message, previousError) {
+    var err = new Error('[AssetsWebpackPlugin] ' + message);
+
+    return previousError ? assign(err, previousError) : err;
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Emits a json file with assets paths",
     "main": "index.js",
     "scripts": {
-        "lint": "./node_modules/.bin/eslint --fix index.js lib/**",
+        "lint": "./node_modules/.bin/eslint --fix .",
         "test": "npm run lint && ./node_modules/.bin/mocha test"
     },
     "repository": {
@@ -43,16 +43,18 @@
         "mkdirp": "^0.5.1"
     },
     "eslintConfig": {
+        "root": true,
         "env": {
             "node": true
         },
         "extends": "eslint:recommended",
         "rules": {
             "indent": [2, 4],
-            "quotes": [2, "single"],
+            "quotes": [2, "single", "avoid-escape"],
             "linebreak-style": [2, "unix"],
             "semi": [2, "always"],
-            "no-multi-spaces": 2
+            "no-multi-spaces": 2,
+            "space-before-function-paren": [2, "always"]
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,42 +1,58 @@
 {
-  "name": "assets-webpack-plugin",
-  "version": "2.2.3",
-  "description": "Emits a json file with assets paths",
-  "main": "index.js",
-  "scripts": {
-    "test": "jshint *.js test && ./node_modules/.bin/mocha test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sporto/assets-webpack-plugin.git"
-  },
-  "keywords": [
-    "webpack",
-    "plugin",
-    "generate",
-    "assets",
-    "hashes"
-  ],
-  "author": "Sebastian Porto",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/sporto/assets-webpack-plugin/issues"
-  },
-  "homepage": "https://github.com/sporto/assets-webpack-plugin",
-  "devDependencies": {
-    "chai": "^3.0.0",
-    "css-loader": "^0.9.1",
-    "extract-text-webpack-plugin": "^0.3.8",
-    "jshint": "^2.5.2",
-    "lodash": "^3.9.3",
-    "mocha": "^2.2.5",
-    "rimraf": "^2.2.8",
-    "style-loader": "^0.8.3",
-    "webpack": "^1.3.3-beta1"
-  },
-  "dependencies": {
-    "camelcase": "^1.2.1",
-    "escape-string-regexp": "^1.0.3",
-    "mkdirp": "^0.5.1"
-  }
+    "name": "assets-webpack-plugin",
+    "version": "2.2.3",
+    "description": "Emits a json file with assets paths",
+    "main": "index.js",
+    "scripts": {
+        "lint": "./node_modules/.bin/eslint --fix index.js lib/**",
+        "test": "npm run lint && ./node_modules/.bin/mocha test"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/sporto/assets-webpack-plugin.git"
+    },
+    "keywords": [
+        "webpack",
+        "plugin",
+        "generate",
+        "assets",
+        "hashes"
+    ],
+    "author": "Sebastian Porto",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/sporto/assets-webpack-plugin/issues"
+    },
+    "homepage": "https://github.com/sporto/assets-webpack-plugin",
+    "devDependencies": {
+        "chai": "^3.0.0",
+        "css-loader": "^0.9.1",
+        "eslint": "^1.6.0",
+        "extract-text-webpack-plugin": "^0.3.8",
+        "lodash": "^3.9.3",
+        "mocha": "^2.2.5",
+        "rimraf": "^2.2.8",
+        "style-loader": "^0.8.3",
+        "webpack": "^1.3.3-beta1"
+    },
+    "dependencies": {
+        "camelcase": "^1.2.1",
+        "escape-string-regexp": "^1.0.3",
+        "lodash.assign": "^3.2.0",
+        "lodash.merge": "^3.3.2",
+        "mkdirp": "^0.5.1"
+    },
+    "eslintConfig": {
+        "env": {
+            "node": true
+        },
+        "extends": "eslint:recommended",
+        "rules": {
+            "indent": [2, 4],
+            "quotes": [2, "single"],
+            "linebreak-style": [2, "unix"],
+            "semi": [2, "always"],
+            "no-multi-spaces": 2
+        }
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ The output is a JSON object in the form:
 Where:
 
   * `"bundle_name"` is the name of the bundle (the key of the entry object in your webpack config, or "main" if your entry is an array).
-  * `"asset_kind"` is the camel-cased file extension of the asset, except for source maps where `asset_kind = camelcase(file_xtension) + 'SourceMap'`.
+  * `"asset_kind"` is the camel-cased file extension of the asset
 
 For example, given the following webpack config:
 
@@ -39,8 +39,7 @@ For example, given the following webpack config:
     output: {
         path: path.join(__dirname, "public", "js"),
         publicPath: "/js/",
-        filename: '[name]_[hash].bundle.js',
-        sourceMapFilename: '[file].map'
+        filename: '[name]_[hash].bundle.js'
     }
 }
 ```
@@ -50,12 +49,10 @@ The plugin will output the following json file:
 ```json
 {
     "one": {
-        "js": "/js/one_2bb80372ebe8047a68d4.bundle.js",
-        "jsSourceMap": "/js/one_2bb80372ebe8047a68d4.bundle.js.map"
+        "js": "/js/one_2bb80372ebe8047a68d4.bundle.js"
     },
     "two": {
-        "js": "/js/two_2bb80372ebe8047a68d4.bundle.js",
-        "jsSourceMap": "/js/two_2bb80372ebe8047a68d4.bundle.js.map"
+        "js": "/js/two_2bb80372ebe8047a68d4.bundle.js"
     }
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -100,10 +100,42 @@ __filename__: Name for the created json file. Defaults to `webpack-assets.json`
 new AssetsPlugin({filename: 'assets.json'})
 ```
 
+__update__: When set to true, the output json file will be updated instead of overwritten. Defaults to false.
+
+```js
+new AssetsPlugin({update: true})
+```
+
 __prettyPrint__: Whether to format the json output for readability. Defaults to false.
 
 ```js
 new AssetsPlugin({prettyPrint: true})
+```
+
+### Using in multi-compiler mode
+
+If you use webpack multi-compiler mode and want your assets written to a single file,
+you __must__ use the same instance of the plugin in the different configurations.
+
+For example:
+
+```js
+var webpack = require('webpack');
+var AssetsPlugin = require('assets-webpack-plugin');
+var assetsPluginInstance = new AssetsPlugin();
+
+webpack([
+    {
+        entry: {one: 'src/one.js'},
+        output: {path: 'build', filename: 'one-bundle.js'},
+        plugins: [assetsPluginInstance]
+    },
+    {
+        entry: {two:'src/two.js'},
+        output: {path: 'build', filename: 'two-bundle.js'},
+        plugins: [assetsPluginInstance]
+    }
+]);
 ```
 
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "env": {
+        "node": true,
+        "mocha": true
+    }
+}

--- a/test/getAssetKind.test.js
+++ b/test/getAssetKind.test.js
@@ -33,34 +33,5 @@ describe('getAssetKind', function() {
 
     });
 
-    describe('map', function() {
-
-        it('returns map', function() {
-            var input = 'desktop.js.map';
-            var res = getAssetKind(webpackConfig, input);
-            expect(res).to.eq('jsSourceMap');
-        });
-
-        it('returns map', function() {
-            var input = 'desktop.js.map?9b913c8594ce98e06b21';
-            var res = getAssetKind(webpackConfig, input);
-            expect(res).to.eq('jsSourceMap');
-        });
-
-        it('detects sourcemap even without extension', function() {
-            webpackConfig = {
-                output: {
-                    filename: '[name].js?[hash]',
-                    sourceMapFilename: 'srcmap_[hash]_[file][query]'
-                },
-                devtool: 'sourcemap'
-            };
-            var input = 'srcmap_9b913c8594ce98e06b21_desktop.js?9b913c8594ce98e06b21';
-            var res = getAssetKind(webpackConfig, input);
-            expect(res).to.eq('jsSourceMap');
-        });
-
-    });
-
 });
 

--- a/test/getAssetKind.test.js
+++ b/test/getAssetKind.test.js
@@ -1,10 +1,9 @@
-var webpack = require('webpack');
-var getAssetKind  = require('../lib/getAssetKind.js');
+var getAssetKind = require('../lib/getAssetKind.js');
 var chai = require('chai');
 var expect = chai.expect;
 
 
-describe('getAssetKind', function() {
+describe('getAssetKind', function () {
     var webpackConfig;
 
     beforeEach(function () {
@@ -17,7 +16,7 @@ describe('getAssetKind', function() {
         };
     });
 
-    describe('js', function() {
+    describe('js', function () {
 
         it('returns js', function () {
             var input = 'desktop.js';
@@ -25,7 +24,7 @@ describe('getAssetKind', function() {
             expect(res).to.eq('js');
         });
 
-        it('returns js with hash', function() {
+        it('returns js with hash', function () {
             var input = 'desktop.js?9b913c8594ce98e06b21';
             var res = getAssetKind(webpackConfig, input);
             expect(res).to.eq('js');

--- a/test/getFileExt.test.js
+++ b/test/getFileExt.test.js
@@ -1,23 +1,21 @@
 var getFileExtension = require('../lib/getFileExtension');
-var chai = require('chai');
-var expect = chai.expect;
+var expect = require('chai').expect;
 
 
-function expectExtension(fileName, expected) {
+function expectExtension (fileName, expected) {
     var actual = getFileExtension(fileName) ;
     expect(actual).to.eq(expected);
 }
 
 
-describe('getFileExt', function() {
-    var webpackConfig;
+describe('getFileExt', function () {
 
-    it('returns the right extension with simple file names', function() {
+    it('returns the right extension with simple file names', function () {
         expectExtension('main.js', 'js');
         expectExtension('main-9b913c8594ce98e06b21.js', 'js');
     });
 
-    it('returns the right extension with query  strings', function() {
+    it('returns the right extension with query  strings', function () {
         expectExtension('main.js?9b913c8594ce98e06b21', 'js');
         expectExtension('desktop.js.map?9b913c8594ce98e06b21', 'map');
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,6 @@
 /*jshint expr: true*/
 
 var path = require('path');
-var fs = require('fs');
 // var mocha = require('mocha');
 var chai = require('chai');
 var webpack = require('webpack');
@@ -13,50 +12,8 @@ var Plugin = require('../index.js');
 var expect = chai.expect;
 
 var OUTPUT_DIR = path.join(__dirname, '../tmp');
+var expectOutput = require('./utils/expectOutput')(OUTPUT_DIR);
 
-
-function expectOutput(args, done) {
-    if (!args.config) {
-        throw new Error('Expected args.config');
-    }
-    if (!args.expected) {
-        throw new Error('Expected args.expected');
-    }
-    if (!done) {
-        throw new Error('Expected done');
-    }
-
-    var webpackConfig  = args.config;
-    var expectedResult = args.expected;
-    var outputFile     = args.outputFile;
-
-    // Create output folder
-    mkdirp(OUTPUT_DIR, function(err) {
-        expect(err).to.be.null;
-
-        outputFile = outputFile || 'webpack-assets.json';
-
-        webpack(webpackConfig, function(err, stats) {
-            expect(err).to.be.null;
-            expect(stats.hasErrors()).to.be.false;
-
-            var content = fs.readFileSync(path.join(OUTPUT_DIR, outputFile)).toString();
-
-            if (_.isRegExp(expectedResult)) {
-                expect(content).to.match(expectedResult);
-            } else if(_.isString(expectedResult)) {
-                expect(content).to.contain(expectedResult);
-            } else {
-                // JSON object provided
-                var actual = JSON.parse(content);
-                expect(actual).to.eql(expectedResult);
-            }
-
-            done();
-        });
-
-    });
-}
 
 describe('Plugin', function() {
 
@@ -253,53 +210,6 @@ describe('Plugin', function() {
             styles: {
                 js:  "styles-bundle.js",
                 css: "styles-bundle.css"
-            }
-        };
-
-        var args = {
-            config: webpackConfig,
-            expected: expected
-        };
-
-        expectOutput(args, done);
-    });
-
-    it.skip('generates a default file with multiple compilers', function(done) {
-        var webpackConfig = [
-            {
-                entry: {
-                    one: path.join(__dirname, 'fixtures/one.js')
-                },
-                output: {
-                    path: OUTPUT_DIR,
-                    filename: 'one-bundle.js'
-                },
-                plugins: [new Plugin({
-                    multiCompiler: true,
-                    path: 'tmp'
-                })]
-            },
-            {
-                entry: {
-                    two: path.join(__dirname, 'fixtures/two.js')
-                },
-                output: {
-                    path: OUTPUT_DIR,
-                    filename: 'two-bundle.js'
-                },
-                plugins: [new Plugin({
-                    multiCompiler: true,
-                    path: 'tmp'
-                })]
-            }
-        ];
-
-        var expected = {
-            one: {
-                js: "one-bundle.js"
-            },
-            two: {
-                js: "two-bundle.js"
             }
         };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,27 +1,22 @@
 /*jshint expr: true*/
 
 var path = require('path');
-// var mocha = require('mocha');
-var chai = require('chai');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var rm_rf = require('rimraf');
-var mkdirp = require('mkdirp');
-var _ = require('lodash');
 var Plugin = require('../index.js');
-var expect = chai.expect;
 
 var OUTPUT_DIR = path.join(__dirname, '../tmp');
 var expectOutput = require('./utils/expectOutput')(OUTPUT_DIR);
 
 
-describe('Plugin', function() {
+describe('Plugin', function () {
 
-    beforeEach(function(done) {
+    beforeEach(function (done) {
         rm_rf(OUTPUT_DIR, done);
     });
 
-    it('generates a default file for a single entry point', function(done) {
+    it('generates a default file for a single entry point', function (done) {
         var webpackConfig = {
             entry: path.join(__dirname, 'fixtures/one.js'),
             output: {
@@ -48,7 +43,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('generates a default file with multiple entry points', function(done) {
+    it('generates a default file with multiple entry points', function (done) {
         var webpackConfig = {
             entry: {
                 one: path.join(__dirname, 'fixtures/one.js'),
@@ -78,7 +73,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('allows you to specify your own filename', function(done) {
+    it('allows you to specify your own filename', function (done) {
 
         var webpackConfig = {
             entry: path.join(__dirname, 'fixtures/one.js'),
@@ -107,7 +102,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('skips source maps', function(done) {
+    it('skips source maps', function (done) {
 
         var webpackConfig = {
             devtool: 'sourcemap',
@@ -133,7 +128,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('handles hashes in bundle filenames', function(done) {
+    it('handles hashes in bundle filenames', function (done) {
 
         var webpackConfig = {
             entry: path.join(__dirname, 'fixtures/one.js'),
@@ -154,7 +149,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('handles hashes in a different position', function(done) {
+    it('handles hashes in a different position', function (done) {
 
         var webpackConfig = {
             entry: path.join(__dirname, 'fixtures/one.js'),
@@ -175,7 +170,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('works with ExtractTextPlugin for stylesheets', function(done) {
+    it('works with ExtractTextPlugin for stylesheets', function (done) {
 
         var webpackConfig = {
             entry: {
@@ -202,14 +197,14 @@ describe('Plugin', function() {
 
         var expected = {
             one: {
-                js: "one-bundle.js"
+                js: 'one-bundle.js'
             },
             two: {
-                js: "two-bundle.js"
+                js: 'two-bundle.js'
             },
             styles: {
-                js:  "styles-bundle.js",
-                css: "styles-bundle.css"
+                js:  'styles-bundle.js',
+                css: 'styles-bundle.css'
             }
         };
 
@@ -221,7 +216,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('includes full publicPath', function(done) {
+    it('includes full publicPath', function (done) {
 
         var webpackConfig = {
             entry: path.join(__dirname, 'fixtures/one.js'),
@@ -254,7 +249,7 @@ describe('Plugin', function() {
                 filename: '[name].js'
             },
             plugins: [
-                new webpack.optimize.CommonsChunkPlugin({name: "common"}),
+                new webpack.optimize.CommonsChunkPlugin({name: 'common'}),
                 new Plugin({path: 'tmp'})
             ]
         };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -150,7 +150,7 @@ describe('Plugin', function() {
         expectOutput(args, done);
     });
 
-    it('works with source maps', function(done) {
+    it('skips source maps', function(done) {
 
         var webpackConfig = {
             devtool: 'sourcemap',
@@ -164,31 +164,9 @@ describe('Plugin', function() {
 
         var expected = {
             main: {
-                js: 'index-bundle.js',
-                jsSourceMap: 'index-bundle.js.map'
+                js: 'index-bundle.js'
             }
         };
-
-        var args = {
-            config: webpackConfig,
-            expected: expected
-        };
-
-        expectOutput(args, done);
-    });
-
-    it('works with source maps and hash', function(done) {
-        var webpackConfig = {
-            devtool: 'sourcemap',
-            entry: path.join(__dirname, 'fixtures/one.js'),
-            output: {
-                path: OUTPUT_DIR,
-                filename: 'index-bundle-[hash].js'
-            },
-            plugins: [new Plugin({path: 'tmp'})]
-        };
-
-        var expected = /{"main":{"js":"index-bundle-[0-9a-f]+\.js","jsSourceMap":"index-bundle-[0-9a-f]+\.js\.map"}}/;
 
         var args = {
             config: webpackConfig,

--- a/test/multiCompiler.test.js
+++ b/test/multiCompiler.test.js
@@ -1,27 +1,23 @@
 /*jshint expr: true*/
 
 var path = require('path');
-// var mocha = require('mocha');
-var chai = require('chai');
+var expect = require('chai').expect;
 var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var rm_rf = require('rimraf');
-var mkdirp = require('mkdirp');
-var _ = require('lodash');
+
 var Plugin = require('../index.js');
-var expect = chai.expect;
 
 var OUTPUT_DIR = path.join(__dirname, '../tmp');
 var expectOutput = require('./utils/expectOutput')(OUTPUT_DIR);
 
 
-describe('Plugin with multi-compiler', function() {
+describe('Plugin', function () {
 
-    beforeEach(function(done) {
+    beforeEach(function (done) {
         rm_rf(OUTPUT_DIR, done);
     });
 
-    it('generates a default file with multiple compilers', function(done) {
+    it('works in multi-compiler mode', function (done) {
         var plugin = new Plugin({path: 'tmp'});
 
         var webpackConfig = [
@@ -49,10 +45,10 @@ describe('Plugin with multi-compiler', function() {
 
         var expected = {
             one: {
-                js: "one-bundle.js"
+                js: 'one-bundle.js'
             },
             two: {
-                js: "two-bundle.js"
+                js: 'two-bundle.js'
             }
         };
 
@@ -62,5 +58,69 @@ describe('Plugin with multi-compiler', function() {
         };
 
         expectOutput(args, done);
+    });
+
+    it('updates output between compiler calls when options.update is true', function (done) {
+        var config_1 = {
+            entry: {
+                one: path.join(__dirname, 'fixtures/one.js')
+            },
+            output: {
+                path: OUTPUT_DIR,
+                filename: 'one-bundle.js'
+            },
+            plugins: [new Plugin({path: 'tmp', update: true})]
+        };
+        var config_2 = {
+            entry: {
+                two: path.join(__dirname, 'fixtures/two.js')
+            },
+            output: {
+                path: OUTPUT_DIR,
+                filename: 'two-bundle.js'
+            },
+            plugins: [new Plugin({path: 'tmp', update: true})]
+        };
+
+        var expected = {one: {js: 'one-bundle.js'}, two: {js: 'two-bundle.js'}};
+        var args = {config: config_2, expected: expected};
+
+        webpack(config_1, function (err, stats) {
+            expect(err).to.be.null;
+            expect(stats.hasErrors()).to.be.false;
+            expectOutput(args, done);
+        });
+    });
+
+    it('overwrites output between compiler calls when options.update is false', function (done) {
+        var config_1 = {
+            entry: {
+                one: path.join(__dirname, 'fixtures/one.js')
+            },
+            output: {
+                path: OUTPUT_DIR,
+                filename: 'one-bundle.js'
+            },
+            plugins: [new Plugin({path: 'tmp', update: false})]
+        };
+        var config_2 = {
+            entry: {
+                two: path.join(__dirname, 'fixtures/two.js')
+            },
+            output: {
+                path: OUTPUT_DIR,
+                filename: 'two-bundle.js'
+            },
+            plugins: [new Plugin({path: 'tmp', update: false})]
+        };
+
+        var expected = {two: {js: 'two-bundle.js'}};
+        var args = {config: config_2, expected: expected};
+
+        webpack(config_1, function (err, stats) {
+            expect(err).to.be.null;
+            expect(stats.hasErrors()).to.be.false;
+            expectOutput(args, done);
+        });
     });
 });

--- a/test/multiCompiler.test.js
+++ b/test/multiCompiler.test.js
@@ -1,0 +1,66 @@
+/*jshint expr: true*/
+
+var path = require('path');
+// var mocha = require('mocha');
+var chai = require('chai');
+var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var rm_rf = require('rimraf');
+var mkdirp = require('mkdirp');
+var _ = require('lodash');
+var Plugin = require('../index.js');
+var expect = chai.expect;
+
+var OUTPUT_DIR = path.join(__dirname, '../tmp');
+var expectOutput = require('./utils/expectOutput')(OUTPUT_DIR);
+
+
+describe('Plugin with multi-compiler', function() {
+
+    beforeEach(function(done) {
+        rm_rf(OUTPUT_DIR, done);
+    });
+
+    it('generates a default file with multiple compilers', function(done) {
+        var plugin = new Plugin({path: 'tmp'});
+
+        var webpackConfig = [
+            {
+                entry: {
+                    one: path.join(__dirname, 'fixtures/one.js')
+                },
+                output: {
+                    path: OUTPUT_DIR,
+                    filename: 'one-bundle.js'
+                },
+                plugins: [plugin]
+            },
+            {
+                entry: {
+                    two: path.join(__dirname, 'fixtures/two.js')
+                },
+                output: {
+                    path: OUTPUT_DIR,
+                    filename: 'two-bundle.js'
+                },
+                plugins: [plugin]
+            }
+        ];
+
+        var expected = {
+            one: {
+                js: "one-bundle.js"
+            },
+            two: {
+                js: "two-bundle.js"
+            }
+        };
+
+        var args = {
+            config: webpackConfig,
+            expected: expected
+        };
+
+        expectOutput(args, done);
+    });
+});

--- a/test/utils/expectOutput.js
+++ b/test/utils/expectOutput.js
@@ -19,17 +19,17 @@ module.exports = function (outputDir) {
             throw new Error('Expected done');
         }
 
-        var webpackConfig  = args.config;
+        var webpackConfig = args.config;
         var expectedResult = args.expected;
-        var outputFile     = args.outputFile;
+        var outputFile = args.outputFile;
 
         // Create output folder
-        mkdirp(outputDir, function(err) {
+        mkdirp(outputDir, function (err) {
             expect(err).to.be.null;
 
             outputFile = outputFile || 'webpack-assets.json';
 
-            webpack(webpackConfig, function(err, stats) {
+            webpack(webpackConfig, function (err, stats) {
                 expect(err).to.be.null;
                 expect(stats.hasErrors()).to.be.false;
 

--- a/test/utils/expectOutput.js
+++ b/test/utils/expectOutput.js
@@ -1,0 +1,53 @@
+var _ = require('lodash');
+var expect = require('chai').expect;
+var mkdirp = require('mkdirp');
+var webpack = require('webpack');
+var fs = require('fs');
+var path = require('path');
+
+
+module.exports = function (outputDir) {
+
+    return function expectOutput (args, done) {
+        if (!args.config) {
+            throw new Error('Expected args.config');
+        }
+        if (!args.expected) {
+            throw new Error('Expected args.expected');
+        }
+        if (!done) {
+            throw new Error('Expected done');
+        }
+
+        var webpackConfig  = args.config;
+        var expectedResult = args.expected;
+        var outputFile     = args.outputFile;
+
+        // Create output folder
+        mkdirp(outputDir, function(err) {
+            expect(err).to.be.null;
+
+            outputFile = outputFile || 'webpack-assets.json';
+
+            webpack(webpackConfig, function(err, stats) {
+                expect(err).to.be.null;
+                expect(stats.hasErrors()).to.be.false;
+
+                var content = fs.readFileSync(path.join(outputDir, outputFile)).toString();
+
+                if (_.isRegExp(expectedResult)) {
+                    expect(content).to.match(expectedResult);
+                } else if(_.isString(expectedResult)) {
+                    expect(content).to.contain(expectedResult);
+                } else {
+                    // JSON object provided
+                    var actual = JSON.parse(content);
+                    expect(actual).to.eql(expectedResult);
+                }
+
+                done();
+            });
+
+        });
+    };
+};


### PR DESCRIPTION
Hi,
as evoked in #24, the plugin now skips sourcemaps as well as hot module updates.
As a bonus, I re-introduced support (with passing tests) for the multi-compiler mode,
and a new `update` option. (see the readme).
