### PR TITLE
Adds the flag to not inlude the publicPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,18 +30,18 @@ AssetsWebpackPlugin.prototype = {
 
       var options = compiler.options;
       var stats = compilation.getStats().toJson({
-          hash: true,
-          publicPath: true,
-          assets: true,
-          chunks: false,
-          modules: false,
-          source: false,
-          errorDetails: false,
-          timings: false
-        });
+        hash: true,
+        publicPath: true,
+        assets: true,
+        chunks: false,
+        modules: false,
+        source: false,
+        errorDetails: false,
+        timings: false
+      });
             // publicPath with resolved [hash] placeholder
 
-      var assetPath  = stats.publicPath && self.options.fullPath ? stats.publicPath : '';
+      var assetPath = (stats.publicPath && self.options.fullPath) ? stats.publicPath : '';
             // assetsByChunkName contains a hash with the bundle names and the produced files
             // e.g. { one: 'one-bundle.js', two: 'two-bundle.js' }
             // in some cases (when using a plugin or source maps) it might contain an array of produced files
@@ -53,30 +53,30 @@ AssetsWebpackPlugin.prototype = {
       var assetsByChunkName = stats.assetsByChunkName;
 
       var output = Object.keys(assetsByChunkName).reduce(function (chunkMap, chunkName) {
-          var assets = assetsByChunkName[chunkName];
-          if (!Array.isArray(assets)) {
-              assets = [assets];
-            }
-          chunkMap[chunkName] = assets.reduce(function (typeMap, asset) {
-              if (isHMRUpdate(options, asset) || isSourceMap(options, asset)) {
-                  return typeMap;
-                }
+        var assets = assetsByChunkName[chunkName];
+        if (!Array.isArray(assets)) {
+          assets = [assets];
+        }
+        chunkMap[chunkName] = assets.reduce(function (typeMap, asset) {
+          if (isHMRUpdate(options, asset) || isSourceMap(options, asset)) {
+            return typeMap;
+          }
 
-              var typeName = getAssetKind(options, asset);
-              typeMap[typeName] = assetPath + asset;
+          var typeName = getAssetKind(options, asset);
+          typeMap[typeName] = assetPath + asset;
 
-              return typeMap;
-            }, {});
-
-          return chunkMap;
+          return typeMap;
         }, {});
 
+        return chunkMap;
+      }, {});
+
       self.writer(output, function (err) {
-          if (err) {
-              compilation.errors.push(err);
-            }
-          callback();
-        });
+        if (err) {
+          compilation.errors.push(err);
+        }
+        callback();
+      });
 
     });
   }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function AssetsWebpackPlugin (options) {
     path: '.',
     filename: 'webpack-assets.json',
     prettyPrint: false,
-    update: false
+    update: false,
+    fullPath: true
   }, options);
   this.writer = createQueuedWriter(createOutputWriter(this.options));
 }
@@ -27,19 +28,20 @@ AssetsWebpackPlugin.prototype = {
 
     compiler.plugin('after-emit', function (compilation, callback) {
 
-        var options = compiler.options;
-        var stats = compilation.getStats().toJson({
-            hash: true,
-            publicPath: true,
-            assets: true,
-            chunks: false,
-            modules: false,
-            source: false,
-            errorDetails: false,
-            timings: false
-          });
+      var options = compiler.options;
+      var stats = compilation.getStats().toJson({
+          hash: true,
+          publicPath: true,
+          assets: true,
+          chunks: false,
+          modules: false,
+          source: false,
+          errorDetails: false,
+          timings: false
+        });
             // publicPath with resolved [hash] placeholder
-        var publicPath = stats.publicPath || '';
+
+      var assetPath  = stats.publicPath && self.options.fullPath ? stats.publicPath : '';
             // assetsByChunkName contains a hash with the bundle names and the produced files
             // e.g. { one: 'one-bundle.js', two: 'two-bundle.js' }
             // in some cases (when using a plugin or source maps) it might contain an array of produced files
@@ -48,35 +50,35 @@ AssetsWebpackPlugin.prototype = {
             //   [ 'index-bundle-42b6e1ec4fa8c5f0303e.js',
             //     'index-bundle-42b6e1ec4fa8c5f0303e.js.map' ]
             // }
-        var assetsByChunkName = stats.assetsByChunkName;
+      var assetsByChunkName = stats.assetsByChunkName;
 
-        var output = Object.keys(assetsByChunkName).reduce(function (chunkMap, chunkName) {
-            var assets = assetsByChunkName[chunkName];
-            if (!Array.isArray(assets)) {
-                assets = [assets];
-              }
-            chunkMap[chunkName] = assets.reduce(function (typeMap, asset) {
-                if (isHMRUpdate(options, asset) || isSourceMap(options, asset)) {
-                    return typeMap;
-                  }
+      var output = Object.keys(assetsByChunkName).reduce(function (chunkMap, chunkName) {
+          var assets = assetsByChunkName[chunkName];
+          if (!Array.isArray(assets)) {
+              assets = [assets];
+            }
+          chunkMap[chunkName] = assets.reduce(function (typeMap, asset) {
+              if (isHMRUpdate(options, asset) || isSourceMap(options, asset)) {
+                  return typeMap;
+                }
 
-                var typeName = getAssetKind(options, asset);
-                typeMap[typeName] = publicPath + asset;
+              var typeName = getAssetKind(options, asset);
+              typeMap[typeName] = assetPath + asset;
 
-                return typeMap;
-              }, {});
+              return typeMap;
+            }, {});
 
-            return chunkMap;
-          }, {});
+          return chunkMap;
+        }, {});
 
-        self.writer(output, function (err) {
-            if (err) {
-                compilation.errors.push(err);
-              }
-            callback();
-          });
+      self.writer(output, function (err) {
+          if (err) {
+              compilation.errors.push(err);
+            }
+          callback();
+        });
 
-      });
+    });
   }
 };
 

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -16,36 +16,36 @@ module.exports = function (options) {
     var overwrite = !update && firstRun;
 
     mkdirp(options.path, function (err) {
-        if (err) {
-            return next(error('Could not create output folder ' + options.path, err));
-          }
-        fs.readFile(outputPath, 'utf8', function (err, data) {
+      if (err) {
+          return next(error('Could not create output folder ' + options.path, err));
+        }
+      fs.readFile(outputPath, 'utf8', function (err, data) {
                 // if file does not exist, just write data to it
-            if (err && err.code !== 'ENOENT') {
-                return next(error('Could not read output file ' + outputPath, err));
-              }
+          if (err && err.code !== 'ENOENT') {
+              return next(error('Could not read output file ' + outputPath, err));
+            }
                 // if options.update is false and we're on first run,
                 // start with empty data
-            data = overwrite ? '{}' : data || '{}';
+          data = overwrite ? '{}' : data || '{}';
 
-            var oldAssets;
-            try {
-                oldAssets = JSON.parse(data);
-              } catch (err) {
-                  oldAssets = {};
+          var oldAssets;
+          try {
+              oldAssets = JSON.parse(data);
+            } catch (err) {
+                oldAssets = {};
+              }
+
+          var assets = merge({}, oldAssets, newAssets);
+          var output = JSON.stringify(assets, null, options.prettyPrint ? 2 : null);
+
+          fs.writeFile(outputPath, output, function (err) {
+              if (err) {
+                  return next(error('Unable to write to ' + outputPath, err));
                 }
-
-            var assets = merge({}, oldAssets, newAssets);
-            var output = JSON.stringify(assets, null, options.prettyPrint ? 2 : null);
-
-            fs.writeFile(outputPath, output, function (err) {
-                if (err) {
-                    return next(error('Unable to write to ' + outputPath, err));
-                  }
-                firstRun = false;
-                next();
-              });
-          });
-      });
+              firstRun = false;
+              next();
+            });
+        });
+    });
   };
 };

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -17,35 +17,35 @@ module.exports = function (options) {
 
     mkdirp(options.path, function (err) {
       if (err) {
-          return next(error('Could not create output folder ' + options.path, err));
-        }
+        return next(error('Could not create output folder ' + options.path, err));
+      }
       fs.readFile(outputPath, 'utf8', function (err, data) {
                 // if file does not exist, just write data to it
-          if (err && err.code !== 'ENOENT') {
-              return next(error('Could not read output file ' + outputPath, err));
-            }
+        if (err && err.code !== 'ENOENT') {
+          return next(error('Could not read output file ' + outputPath, err));
+        }
                 // if options.update is false and we're on first run,
                 // start with empty data
-          data = overwrite ? '{}' : data || '{}';
+        data = overwrite ? '{}' : data || '{}';
 
-          var oldAssets;
-          try {
-              oldAssets = JSON.parse(data);
-            } catch (err) {
-                oldAssets = {};
-              }
+        var oldAssets;
+        try {
+          oldAssets = JSON.parse(data);
+        } catch (err) {
+          oldAssets = {};
+        }
 
-          var assets = merge({}, oldAssets, newAssets);
-          var output = JSON.stringify(assets, null, options.prettyPrint ? 2 : null);
+        var assets = merge({}, oldAssets, newAssets);
+        var output = JSON.stringify(assets, null, options.prettyPrint ? 2 : null);
 
-          fs.writeFile(outputPath, output, function (err) {
-              if (err) {
-                  return next(error('Unable to write to ' + outputPath, err));
-                }
-              firstRun = false;
-              next();
-            });
+        fs.writeFile(outputPath, output, function (err) {
+          if (err) {
+            return next(error('Unable to write to ' + outputPath, err));
+          }
+          firstRun = false;
+          next();
         });
+      });
     });
   };
 };

--- a/lib/output/createQueuedWriter.js
+++ b/lib/output/createQueuedWriter.js
@@ -16,8 +16,8 @@ module.exports = function createQueuedWriter (processor) {
 
       var next = queue[0];
       if (next) {
-          processor(next.data, iterator(next.callback));
-        }
+        processor(next.data, iterator(next.callback));
+      }
     };
   };
 

--- a/lib/output/createQueuedWriter.js
+++ b/lib/output/createQueuedWriter.js
@@ -11,14 +11,14 @@ module.exports = function createQueuedWriter (processor) {
 
   var iterator = function (callback) {
     return function (err) {
-        queue.shift();
-        callback(err);
+      queue.shift();
+      callback(err);
 
-        var next = queue[0];
-        if (next) {
-            processor(next.data, iterator(next.callback));
-          }
-      };
+      var next = queue[0];
+      if (next) {
+          processor(next.data, iterator(next.callback));
+        }
+    };
   };
 
   return function queuedWriter (data, callback) {
@@ -27,7 +27,7 @@ module.exports = function createQueuedWriter (processor) {
 
     if (empty) {
             // start processing
-        processor(data, iterator(callback));
-      }
+      processor(data, iterator(callback));
+    }
   };
 };

--- a/lib/pathTemplate.js
+++ b/lib/pathTemplate.js
@@ -43,19 +43,19 @@ PathTemplate.prototype = {
   resolve: function (data) {
     return this.fields.reduce(function (output, field) {
       var replacement = '',
-          placeholder = field.placeholder,
-          width = field.width;
+        placeholder = field.placeholder,
+        width = field.width;
 
       if (field.prefix) {
-          output += field.prefix;
-        }
+        output += field.prefix;
+      }
       if (placeholder) {
-          replacement = data[placeholder] || '';
-          if (width && (placeholder === 'hash' || placeholder === 'chunkhash')) {
-              replacement = replacement.slice(0, width);
-            }
-          output += replacement;
+        replacement = data[placeholder] || '';
+        if (width && (placeholder === 'hash' || placeholder === 'chunkhash')) {
+          replacement = replacement.slice(0, width);
         }
+        output += replacement;
+      }
 
       return output;
     }, '');
@@ -88,37 +88,37 @@ function parseTemplate (str) {
 
     if (!char) {
       fields.push({
-          prefix: prefix,
-          placeholder: null
-        });
+        prefix: prefix,
+        placeholder: null
+      });
       break;
     } else if (char === '[') {
 
-        input = str.slice(pos);
-        match = SIMPLE_PLACEHOLDER_RX.exec(input);
-        if (match) {
-            fields.push({
-              prefix: prefix,
-              placeholder: match[1].toLowerCase()
-            });
-            pos += match[0].length;
-            prefix = '';
-            continue;
-          }
-
-        match = HASH_PLACEHOLDER_RX.exec(input);
-        if (match) {
-            fields.push({
-              prefix: prefix,
-              placeholder: match[1].toLowerCase(),
-              width: parseInt(match[2] || 0, 10)
-            });
-            pos += match[0].length;
-            prefix = '';
-            continue;
-          }
-
+      input = str.slice(pos);
+      match = SIMPLE_PLACEHOLDER_RX.exec(input);
+      if (match) {
+        fields.push({
+          prefix: prefix,
+          placeholder: match[1].toLowerCase()
+        });
+        pos += match[0].length;
+        prefix = '';
+        continue;
       }
+
+      match = HASH_PLACEHOLDER_RX.exec(input);
+      if (match) {
+        fields.push({
+          prefix: prefix,
+          placeholder: match[1].toLowerCase(),
+          width: parseInt(match[2] || 0, 10)
+        });
+        pos += match[0].length;
+        prefix = '';
+        continue;
+      }
+
+    }
     prefix += char;
     pos++;
   }
@@ -141,23 +141,23 @@ function createTemplateMatcher (fields) {
     }
     if (field.placeholder) {
       switch (field.placeholder) {
-        case 'id':
-          pattern += '\\d+';
-          break;
-        case 'hash':
-        case 'chunkhash':
-          pattern += '[0-9a-fA-F]';
-          pattern += field.width ? '{1,' + field.width + '}' : '+';
-          break;
-        case 'name':
-        case 'file':
-        case 'filebase':
-          pattern += '.+?';
-          break;
-        case 'query':
-          pattern += '(?:\\?.+?)?';
-          break;
-        }
+      case 'id':
+        pattern += '\\d+';
+        break;
+      case 'hash':
+      case 'chunkhash':
+        pattern += '[0-9a-fA-F]';
+        pattern += field.width ? '{1,' + field.width + '}' : '+';
+        break;
+      case 'name':
+      case 'file':
+      case 'filebase':
+        pattern += '.+?';
+        break;
+      case 'query':
+        pattern += '(?:\\?.+?)?';
+        break;
+      }
     }
     if (i === length - 1) {
       pattern += '$';

--- a/lib/pathTemplate.js
+++ b/lib/pathTemplate.js
@@ -42,23 +42,23 @@ PathTemplate.prototype = {
      */
   resolve: function (data) {
     return this.fields.reduce(function (output, field) {
-        var replacement = '',
-            placeholder = field.placeholder,
-            width = field.width;
+      var replacement = '',
+          placeholder = field.placeholder,
+          width = field.width;
 
-        if (field.prefix) {
-            output += field.prefix;
-          }
-        if (placeholder) {
-            replacement = data[placeholder] || '';
-            if (width && (placeholder === 'hash' || placeholder === 'chunkhash')) {
-                replacement = replacement.slice(0, width);
-              }
-            output += replacement;
-          }
+      if (field.prefix) {
+          output += field.prefix;
+        }
+      if (placeholder) {
+          replacement = data[placeholder] || '';
+          if (width && (placeholder === 'hash' || placeholder === 'chunkhash')) {
+              replacement = replacement.slice(0, width);
+            }
+          output += replacement;
+        }
 
-        return output;
-      }, '');
+      return output;
+    }, '');
   }
 };
 
@@ -87,38 +87,38 @@ function parseTemplate (str) {
     char = str[pos];
 
     if (!char) {
-        fields.push({
-            prefix: prefix,
-            placeholder: null
-          });
-        break;
-      } else if (char === '[') {
+      fields.push({
+          prefix: prefix,
+          placeholder: null
+        });
+      break;
+    } else if (char === '[') {
 
-          input = str.slice(pos);
-          match = SIMPLE_PLACEHOLDER_RX.exec(input);
-          if (match) {
+        input = str.slice(pos);
+        match = SIMPLE_PLACEHOLDER_RX.exec(input);
+        if (match) {
             fields.push({
-                prefix: prefix,
-                placeholder: match[1].toLowerCase()
-              });
+              prefix: prefix,
+              placeholder: match[1].toLowerCase()
+            });
             pos += match[0].length;
             prefix = '';
             continue;
           }
 
-          match = HASH_PLACEHOLDER_RX.exec(input);
-          if (match) {
+        match = HASH_PLACEHOLDER_RX.exec(input);
+        if (match) {
             fields.push({
-                prefix: prefix,
-                placeholder: match[1].toLowerCase(),
-                width: parseInt(match[2] || 0, 10)
-              });
+              prefix: prefix,
+              placeholder: match[1].toLowerCase(),
+              width: parseInt(match[2] || 0, 10)
+            });
             pos += match[0].length;
             prefix = '';
             continue;
           }
 
-        }
+      }
     prefix += char;
     pos++;
   }
@@ -134,34 +134,34 @@ function createTemplateMatcher (fields) {
   var length = fields.length;
   var pattern = fields.reduce(function (pattern, field, i) {
     if (i === 0) {
-        pattern = '^';
-      }
+      pattern = '^';
+    }
     if (field.prefix) {
-        pattern += '(' + escapeRegExp(field.prefix) + ')';
-      }
+      pattern += '(' + escapeRegExp(field.prefix) + ')';
+    }
     if (field.placeholder) {
-        switch (field.placeholder) {
-          case 'id':
-            pattern += '\\d+';
-            break;
-          case 'hash':
-          case 'chunkhash':
-            pattern += '[0-9a-fA-F]';
-            pattern += field.width ? '{1,' + field.width + '}' : '+';
-            break;
-          case 'name':
-          case 'file':
-          case 'filebase':
-            pattern += '.+?';
-            break;
-          case 'query':
-            pattern += '(?:\\?.+?)?';
-            break;
-          }
-      }
+      switch (field.placeholder) {
+        case 'id':
+          pattern += '\\d+';
+          break;
+        case 'hash':
+        case 'chunkhash':
+          pattern += '[0-9a-fA-F]';
+          pattern += field.width ? '{1,' + field.width + '}' : '+';
+          break;
+        case 'name':
+        case 'file':
+        case 'filebase':
+          pattern += '.+?';
+          break;
+        case 'query':
+          pattern += '(?:\\?.+?)?';
+          break;
+        }
+    }
     if (i === length - 1) {
-        pattern += '$';
-      }
+      pattern += '$';
+    }
 
     return pattern;
   }, '');

--- a/test/getAssetKind.test.js
+++ b/test/getAssetKind.test.js
@@ -9,9 +9,9 @@ describe('getAssetKind', function () {
   beforeEach(function () {
     webpackConfig = {
       output: {
-          filename: '[name].js?[hash]',
-          sourceMapFilename: '[file].map[query]'
-        },
+        filename: '[name].js?[hash]',
+        sourceMapFilename: '[file].map[query]'
+      },
       devtool: 'sourcemap'
     };
   });

--- a/test/getAssetKind.test.js
+++ b/test/getAssetKind.test.js
@@ -8,27 +8,27 @@ describe('getAssetKind', function () {
 
   beforeEach(function () {
     webpackConfig = {
-        output: {
-            filename: '[name].js?[hash]',
-            sourceMapFilename: '[file].map[query]'
-          },
-        devtool: 'sourcemap'
-      };
+      output: {
+          filename: '[name].js?[hash]',
+          sourceMapFilename: '[file].map[query]'
+        },
+      devtool: 'sourcemap'
+    };
   });
 
   describe('js', function () {
 
     it('returns js', function () {
-        var input = 'desktop.js';
-        var res = getAssetKind(webpackConfig, input);
-        expect(res).to.eq('js');
-      });
+      var input = 'desktop.js';
+      var res = getAssetKind(webpackConfig, input);
+      expect(res).to.eq('js');
+    });
 
     it('returns js with hash', function () {
-        var input = 'desktop.js?9b913c8594ce98e06b21';
-        var res = getAssetKind(webpackConfig, input);
-        expect(res).to.eq('js');
-      });
+      var input = 'desktop.js?9b913c8594ce98e06b21';
+      var res = getAssetKind(webpackConfig, input);
+      expect(res).to.eq('js');
+    });
 
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,18 +20,18 @@ describe('Plugin', function () {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          filename: 'index-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'index-bundle.js'
+      },
       plugins: [new Plugin({
-          path: 'tmp'
-        })]
+        path: 'tmp'
+      })]
     };
 
     var expected = {
       main: {
-          js: 'index-bundle.js'
-        }
+        js: 'index-bundle.js'
+      }
     };
     expected = JSON.stringify(expected);
 
@@ -46,23 +46,23 @@ describe('Plugin', function () {
   it('generates a default file with multiple entry points', function (done) {
     var webpackConfig = {
       entry: {
-          one: path.join(__dirname, 'fixtures/one.js'),
-          two: path.join(__dirname, 'fixtures/two.js')
-        },
+        one: path.join(__dirname, 'fixtures/one.js'),
+        two: path.join(__dirname, 'fixtures/two.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: '[name]-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: '[name]-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp'})]
     };
 
     var expected = {
       one: {
-          js: 'one-bundle.js'
-        },
+        js: 'one-bundle.js'
+      },
       two: {
-          js: 'two-bundle.js'
-        }
+        js: 'two-bundle.js'
+      }
     };
 
     var args = {
@@ -78,19 +78,19 @@ describe('Plugin', function () {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          filename: 'index-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'index-bundle.js'
+      },
       plugins: [new Plugin({
-          filename: 'foo.json',
-          path: 'tmp'
-        })]
+        filename: 'foo.json',
+        path: 'tmp'
+      })]
     };
 
     var expected = {
       main: {
-          js: 'index-bundle.js'
-        }
+        js: 'index-bundle.js'
+      }
     };
 
     var args = {
@@ -108,16 +108,16 @@ describe('Plugin', function () {
       devtool: 'sourcemap',
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          filename: 'index-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'index-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp'})]
     };
 
     var expected = {
       main: {
-          js: 'index-bundle.js'
-        }
+        js: 'index-bundle.js'
+      }
     };
 
     var args = {
@@ -133,9 +133,9 @@ describe('Plugin', function () {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          filename: 'index-bundle-[hash].js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'index-bundle-[hash].js'
+      },
       plugins: [new Plugin({path: 'tmp'})]
     };
 
@@ -154,9 +154,9 @@ describe('Plugin', function () {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          filename: '[name].js?[hash]'
-        },
+        path: OUTPUT_DIR,
+        filename: '[name].js?[hash]'
+      },
       plugins: [new Plugin({path: 'tmp'})]
     };
 
@@ -174,38 +174,38 @@ describe('Plugin', function () {
 
     var webpackConfig = {
       entry: {
-          one: path.join(__dirname, 'fixtures/one.js'),
-          two: path.join(__dirname, 'fixtures/two.js'),
-          styles: path.join(__dirname, 'fixtures/styles.js')
-        },
+        one: path.join(__dirname, 'fixtures/one.js'),
+        two: path.join(__dirname, 'fixtures/two.js'),
+        styles: path.join(__dirname, 'fixtures/styles.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: '[name]-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: '[name]-bundle.js'
+      },
       module: {
-          loaders: [
+        loaders: [
                 {test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader')}
-            ]
-        },
-      plugins: [
-          new ExtractTextPlugin('[name]-bundle.css', {allChunks: true}),
-          new Plugin({
-              path: 'tmp'
-            })
         ]
+      },
+      plugins: [
+        new ExtractTextPlugin('[name]-bundle.css', {allChunks: true}),
+        new Plugin({
+          path: 'tmp'
+        })
+      ]
     };
 
     var expected = {
       one: {
-          js: 'one-bundle.js'
-        },
+        js: 'one-bundle.js'
+      },
       two: {
-          js: 'two-bundle.js'
-        },
+        js: 'two-bundle.js'
+      },
       styles: {
-          js:  'styles-bundle.js',
-          css: 'styles-bundle.css'
-        }
+        js:  'styles-bundle.js',
+        css: 'styles-bundle.css'
+      }
     };
 
     var args = {
@@ -221,10 +221,10 @@ describe('Plugin', function () {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          publicPath: '/public/path/[hash]/',
-          filename: 'index-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        publicPath: '/public/path/[hash]/',
+        filename: 'index-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp'})]
     };
 
@@ -243,15 +243,23 @@ describe('Plugin', function () {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
-          path: OUTPUT_DIR,
-          publicPath: '/public/path/[hash]/',
-          filename: 'index-bundle.js',
-          fullPath: false
-        },
-      plugins: [new Plugin({path: 'tmp'})]
+        path: OUTPUT_DIR,
+        publicPath: '/public/path/[hash]/',
+        filename: 'index-bundle.js'
+      },
+      plugins: [new Plugin({
+        path: 'tmp',
+        fullPath: false
+      })]
     };
 
-    var expected = new RegExp('index-bundle.js', 'i');
+    var expected = {
+      main: {
+        js: 'index-bundle.js'
+      }
+    };
+
+    expected = JSON.stringify(expected);
 
     var args = {
       config: webpackConfig,
@@ -264,17 +272,17 @@ describe('Plugin', function () {
   it('works with CommonChunksPlugin', function (done) {
     var webpackConfig = {
       entry: {
-          one: path.join(__dirname, 'fixtures/common-chunks/one.js'),
-          two: path.join(__dirname, 'fixtures/common-chunks/two.js')
-        },
+        one: path.join(__dirname, 'fixtures/common-chunks/one.js'),
+        two: path.join(__dirname, 'fixtures/common-chunks/two.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: '[name].js'
-        },
+        path: OUTPUT_DIR,
+        filename: '[name].js'
+      },
       plugins: [
-          new webpack.optimize.CommonsChunkPlugin({name: 'common'}),
-          new Plugin({path: 'tmp'})
-        ]
+        new webpack.optimize.CommonsChunkPlugin({name: 'common'}),
+        new Plugin({path: 'tmp'})
+      ]
     };
 
     var expected = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,57 +18,57 @@ describe('Plugin', function () {
 
   it('generates a default file for a single entry point', function (done) {
     var webpackConfig = {
-        entry: path.join(__dirname, 'fixtures/one.js'),
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'index-bundle.js'
-          },
-        plugins: [new Plugin({
-            path: 'tmp'
-          })]
-      };
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'index-bundle.js'
+        },
+      plugins: [new Plugin({
+          path: 'tmp'
+        })]
+    };
 
     var expected = {
-        main: {
-            js: 'index-bundle.js'
-          }
-      };
+      main: {
+          js: 'index-bundle.js'
+        }
+    };
     expected = JSON.stringify(expected);
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
 
   it('generates a default file with multiple entry points', function (done) {
     var webpackConfig = {
-        entry: {
-            one: path.join(__dirname, 'fixtures/one.js'),
-            two: path.join(__dirname, 'fixtures/two.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: '[name]-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp'})]
-      };
+      entry: {
+          one: path.join(__dirname, 'fixtures/one.js'),
+          two: path.join(__dirname, 'fixtures/two.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: '[name]-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp'})]
+    };
 
     var expected = {
-        one: {
-            js: 'one-bundle.js'
-          },
-        two: {
-            js: 'two-bundle.js'
-          }
-      };
+      one: {
+          js: 'one-bundle.js'
+        },
+      two: {
+          js: 'two-bundle.js'
+        }
+    };
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
@@ -76,28 +76,28 @@ describe('Plugin', function () {
   it('allows you to specify your own filename', function (done) {
 
     var webpackConfig = {
-        entry: path.join(__dirname, 'fixtures/one.js'),
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'index-bundle.js'
-          },
-        plugins: [new Plugin({
-            filename: 'foo.json',
-            path: 'tmp'
-          })]
-      };
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'index-bundle.js'
+        },
+      plugins: [new Plugin({
+          filename: 'foo.json',
+          path: 'tmp'
+        })]
+    };
 
     var expected = {
-        main: {
-            js: 'index-bundle.js'
-          }
-      };
+      main: {
+          js: 'index-bundle.js'
+        }
+    };
 
     var args = {
-        config: webpackConfig,
-        expected: expected,
-        outputFile: 'foo.json'
-      };
+      config: webpackConfig,
+      expected: expected,
+      outputFile: 'foo.json'
+    };
 
     expectOutput(args, done);
   });
@@ -105,25 +105,25 @@ describe('Plugin', function () {
   it('skips source maps', function (done) {
 
     var webpackConfig = {
-        devtool: 'sourcemap',
-        entry: path.join(__dirname, 'fixtures/one.js'),
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'index-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp'})]
-      };
+      devtool: 'sourcemap',
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'index-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp'})]
+    };
 
     var expected = {
-        main: {
-            js: 'index-bundle.js'
-          }
-      };
+      main: {
+          js: 'index-bundle.js'
+        }
+    };
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
@@ -131,20 +131,20 @@ describe('Plugin', function () {
   it('handles hashes in bundle filenames', function (done) {
 
     var webpackConfig = {
-        entry: path.join(__dirname, 'fixtures/one.js'),
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'index-bundle-[hash].js'
-          },
-        plugins: [new Plugin({path: 'tmp'})]
-      };
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'index-bundle-[hash].js'
+        },
+      plugins: [new Plugin({path: 'tmp'})]
+    };
 
     var expected = /{"main":{"js":"index-bundle-[0-9a-f]+\.js"}}/;
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
@@ -152,20 +152,20 @@ describe('Plugin', function () {
   it('handles hashes in a different position', function (done) {
 
     var webpackConfig = {
-        entry: path.join(__dirname, 'fixtures/one.js'),
-        output: {
-            path: OUTPUT_DIR,
-            filename: '[name].js?[hash]'
-          },
-        plugins: [new Plugin({path: 'tmp'})]
-      };
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          filename: '[name].js?[hash]'
+        },
+      plugins: [new Plugin({path: 'tmp'})]
+    };
 
     var expected = /{"main":{"js":"main\.js\?[0-9a-f]+"}}/;
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
@@ -173,45 +173,45 @@ describe('Plugin', function () {
   it('works with ExtractTextPlugin for stylesheets', function (done) {
 
     var webpackConfig = {
-        entry: {
-            one: path.join(__dirname, 'fixtures/one.js'),
-            two: path.join(__dirname, 'fixtures/two.js'),
-            styles: path.join(__dirname, 'fixtures/styles.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: '[name]-bundle.js'
-          },
-        module: {
-            loaders: [
+      entry: {
+          one: path.join(__dirname, 'fixtures/one.js'),
+          two: path.join(__dirname, 'fixtures/two.js'),
+          styles: path.join(__dirname, 'fixtures/styles.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: '[name]-bundle.js'
+        },
+      module: {
+          loaders: [
                 {test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader')}
-              ]
-          },
-        plugins: [
-            new ExtractTextPlugin('[name]-bundle.css', {allChunks: true}),
-            new Plugin({
-                path: 'tmp'
-              })
-          ]
-      };
+            ]
+        },
+      plugins: [
+          new ExtractTextPlugin('[name]-bundle.css', {allChunks: true}),
+          new Plugin({
+              path: 'tmp'
+            })
+        ]
+    };
 
     var expected = {
-        one: {
-            js: 'one-bundle.js'
-          },
-        two: {
-            js: 'two-bundle.js'
-          },
-        styles: {
-            js:  'styles-bundle.js',
-            css: 'styles-bundle.css'
-          }
-      };
+      one: {
+          js: 'one-bundle.js'
+        },
+      two: {
+          js: 'two-bundle.js'
+        },
+      styles: {
+          js:  'styles-bundle.js',
+          css: 'styles-bundle.css'
+        }
+    };
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
@@ -219,51 +219,74 @@ describe('Plugin', function () {
   it('includes full publicPath', function (done) {
 
     var webpackConfig = {
-        entry: path.join(__dirname, 'fixtures/one.js'),
-        output: {
-            path: OUTPUT_DIR,
-            publicPath: '/public/path/[hash]/',
-            filename: 'index-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp'})]
-      };
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          publicPath: '/public/path/[hash]/',
+          filename: 'index-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp'})]
+    };
 
     var expected = new RegExp('/public/path/[0-9a-f]+/index-bundle.js', 'i');
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
+
+    expectOutput(args, done);
+  });
+
+  it('doesn\'t include full publicPath', function (done) {
+
+    var webpackConfig = {
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+          path: OUTPUT_DIR,
+          publicPath: '/public/path/[hash]/',
+          filename: 'index-bundle.js',
+          fullPath: false
+        },
+      plugins: [new Plugin({path: 'tmp'})]
+    };
+
+    var expected = new RegExp('index-bundle.js', 'i');
+
+    var args = {
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
 
   it('works with CommonChunksPlugin', function (done) {
     var webpackConfig = {
-        entry: {
-            one: path.join(__dirname, 'fixtures/common-chunks/one.js'),
-            two: path.join(__dirname, 'fixtures/common-chunks/two.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: '[name].js'
-          },
-        plugins: [
-            new webpack.optimize.CommonsChunkPlugin({name: 'common'}),
-            new Plugin({path: 'tmp'})
-          ]
-      };
+      entry: {
+          one: path.join(__dirname, 'fixtures/common-chunks/one.js'),
+          two: path.join(__dirname, 'fixtures/common-chunks/two.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: '[name].js'
+        },
+      plugins: [
+          new webpack.optimize.CommonsChunkPlugin({name: 'common'}),
+          new Plugin({path: 'tmp'})
+        ]
+    };
 
     var expected = {
-        one: {js: 'one.js'},
-        two: {js: 'two.js'},
-        common: {js: 'common.js'}
-      };
+      one: {js: 'one.js'},
+      two: {js: 'two.js'},
+      common: {js: 'common.js'}
+    };
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
 

--- a/test/isHMRUpdate.test.js
+++ b/test/isHMRUpdate.test.js
@@ -8,10 +8,10 @@ describe('isHMRUpdate', function () {
 
   it('detects HMR updates', function () {
     var config = {
-        output: {
-            hotUpdateChunkFilename: 'hmr-yo[id].[hash].js[query]'
-          }
-      };
+      output: {
+          hotUpdateChunkFilename: 'hmr-yo[id].[hash].js[query]'
+        }
+    };
     var input = 'hmr-yo42.b4d455.js?f00b43';
     var res = isHMRUpdate(config, input);
     expect(res).to.eq(true);
@@ -19,10 +19,10 @@ describe('isHMRUpdate', function () {
 
   it('detects HMR updates with tricky templates', function () {
     var config = {
-        output: {
-            hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
-          }
-      };
+      output: {
+          hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
+        }
+    };
     var input = '42940455foo-hmr.js?f00b43';
     var res = isHMRUpdate(config, input);
     expect(res).to.eq(true);
@@ -30,10 +30,10 @@ describe('isHMRUpdate', function () {
 
   it('doesn\'t yield false positives', function () {
     var config = {
-        output: {
-            hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
-          }
-      };
+      output: {
+          hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
+        }
+    };
     expect(isHMRUpdate(config, '42940455foo-hmr?f00b43')).to.eq(false);
   });
 

--- a/test/isHMRUpdate.test.js
+++ b/test/isHMRUpdate.test.js
@@ -9,8 +9,8 @@ describe('isHMRUpdate', function () {
   it('detects HMR updates', function () {
     var config = {
       output: {
-          hotUpdateChunkFilename: 'hmr-yo[id].[hash].js[query]'
-        }
+        hotUpdateChunkFilename: 'hmr-yo[id].[hash].js[query]'
+      }
     };
     var input = 'hmr-yo42.b4d455.js?f00b43';
     var res = isHMRUpdate(config, input);
@@ -20,8 +20,8 @@ describe('isHMRUpdate', function () {
   it('detects HMR updates with tricky templates', function () {
     var config = {
       output: {
-          hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
-        }
+        hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
+      }
     };
     var input = '42940455foo-hmr.js?f00b43';
     var res = isHMRUpdate(config, input);
@@ -31,8 +31,8 @@ describe('isHMRUpdate', function () {
   it('doesn\'t yield false positives', function () {
     var config = {
       output: {
-          hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
-        }
+        hotUpdateChunkFilename: '[id][hash][name]hmr.js[query]'
+      }
     };
     expect(isHMRUpdate(config, '42940455foo-hmr?f00b43')).to.eq(false);
   });

--- a/test/isSourceMap.test.js
+++ b/test/isSourceMap.test.js
@@ -8,10 +8,10 @@ describe('isSourceMap', function () {
 
   it('detects sourcemaps', function () {
     var config = {
-        output: {
-            sourceMapFilename: 'sourcemap-yo[id].[hash].js[query]'
-          }
-      };
+      output: {
+          sourceMapFilename: 'sourcemap-yo[id].[hash].js[query]'
+        }
+    };
     var input = 'sourcemap-yo42.b4d455.js?f00b43';
     var res = isSourceMap(config, input);
     expect(res).to.eq(true);
@@ -19,10 +19,10 @@ describe('isSourceMap', function () {
 
   it('detects sourcemaps with tricky templates', function () {
     var config = {
-        output: {
-            sourceMapFilename: '[id][hash][name]_map.js[query]'
-          }
-      };
+      output: {
+          sourceMapFilename: '[id][hash][name]_map.js[query]'
+        }
+    };
     var input = '42940455foo_map.js?f00b43';
     var res = isSourceMap(config, input);
     expect(res).to.eq(true);
@@ -30,10 +30,10 @@ describe('isSourceMap', function () {
 
   it('doesn\'t yield false positives', function () {
     var config = {
-        output: {
-            sourceMapFilename: '[id][hash][name]_map.js[query]'
-          }
-      };
+      output: {
+          sourceMapFilename: '[id][hash][name]_map.js[query]'
+        }
+    };
     expect(isSourceMap(config, '42940455foo.js?f00b43')).to.eq(false);
   });
 

--- a/test/isSourceMap.test.js
+++ b/test/isSourceMap.test.js
@@ -9,8 +9,8 @@ describe('isSourceMap', function () {
   it('detects sourcemaps', function () {
     var config = {
       output: {
-          sourceMapFilename: 'sourcemap-yo[id].[hash].js[query]'
-        }
+        sourceMapFilename: 'sourcemap-yo[id].[hash].js[query]'
+      }
     };
     var input = 'sourcemap-yo42.b4d455.js?f00b43';
     var res = isSourceMap(config, input);
@@ -20,8 +20,8 @@ describe('isSourceMap', function () {
   it('detects sourcemaps with tricky templates', function () {
     var config = {
       output: {
-          sourceMapFilename: '[id][hash][name]_map.js[query]'
-        }
+        sourceMapFilename: '[id][hash][name]_map.js[query]'
+      }
     };
     var input = '42940455foo_map.js?f00b43';
     var res = isSourceMap(config, input);
@@ -31,8 +31,8 @@ describe('isSourceMap', function () {
   it('doesn\'t yield false positives', function () {
     var config = {
       output: {
-          sourceMapFilename: '[id][hash][name]_map.js[query]'
-        }
+        sourceMapFilename: '[id][hash][name]_map.js[query]'
+      }
     };
     expect(isSourceMap(config, '42940455foo.js?f00b43')).to.eq(false);
   });

--- a/test/multiCompiler.test.js
+++ b/test/multiCompiler.test.js
@@ -23,33 +23,33 @@ describe('Plugin', function () {
     var webpackConfig = [
       {
         entry: {
-            one: path.join(__dirname, 'fixtures/one.js')
-          },
+          one: path.join(__dirname, 'fixtures/one.js')
+        },
         output: {
-            path: OUTPUT_DIR,
-            filename: 'one-bundle.js'
-          },
+          path: OUTPUT_DIR,
+          filename: 'one-bundle.js'
+        },
         plugins: [plugin]
       },
       {
         entry: {
-            two: path.join(__dirname, 'fixtures/two.js')
-          },
+          two: path.join(__dirname, 'fixtures/two.js')
+        },
         output: {
-            path: OUTPUT_DIR,
-            filename: 'two-bundle.js'
-          },
+          path: OUTPUT_DIR,
+          filename: 'two-bundle.js'
+        },
         plugins: [plugin]
       }
     ];
 
     var expected = {
       one: {
-          js: 'one-bundle.js'
-        },
+        js: 'one-bundle.js'
+      },
       two: {
-          js: 'two-bundle.js'
-        }
+        js: 'two-bundle.js'
+      }
     };
 
     var args = {
@@ -63,22 +63,22 @@ describe('Plugin', function () {
   it('updates output between compiler calls when options.update is true', function (done) {
     var config_1 = {
       entry: {
-          one: path.join(__dirname, 'fixtures/one.js')
-        },
+        one: path.join(__dirname, 'fixtures/one.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: 'one-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'one-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp', update: true})]
     };
     var config_2 = {
       entry: {
-          two: path.join(__dirname, 'fixtures/two.js')
-        },
+        two: path.join(__dirname, 'fixtures/two.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: 'two-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'two-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp', update: true})]
     };
 
@@ -95,22 +95,22 @@ describe('Plugin', function () {
   it('overwrites output between compiler calls when options.update is false', function (done) {
     var config_1 = {
       entry: {
-          one: path.join(__dirname, 'fixtures/one.js')
-        },
+        one: path.join(__dirname, 'fixtures/one.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: 'one-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'one-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp', update: false})]
     };
     var config_2 = {
       entry: {
-          two: path.join(__dirname, 'fixtures/two.js')
-        },
+        two: path.join(__dirname, 'fixtures/two.js')
+      },
       output: {
-          path: OUTPUT_DIR,
-          filename: 'two-bundle.js'
-        },
+        path: OUTPUT_DIR,
+        filename: 'two-bundle.js'
+      },
       plugins: [new Plugin({path: 'tmp', update: false})]
     };
 

--- a/test/multiCompiler.test.js
+++ b/test/multiCompiler.test.js
@@ -21,106 +21,106 @@ describe('Plugin', function () {
     var plugin = new Plugin({path: 'tmp'});
 
     var webpackConfig = [
-        {
-          entry: {
-              one: path.join(__dirname, 'fixtures/one.js')
-            },
-          output: {
-              path: OUTPUT_DIR,
-              filename: 'one-bundle.js'
-            },
-          plugins: [plugin]
-        },
-        {
-          entry: {
-              two: path.join(__dirname, 'fixtures/two.js')
-            },
-          output: {
-              path: OUTPUT_DIR,
-              filename: 'two-bundle.js'
-            },
-          plugins: [plugin]
-        }
-      ];
+      {
+        entry: {
+            one: path.join(__dirname, 'fixtures/one.js')
+          },
+        output: {
+            path: OUTPUT_DIR,
+            filename: 'one-bundle.js'
+          },
+        plugins: [plugin]
+      },
+      {
+        entry: {
+            two: path.join(__dirname, 'fixtures/two.js')
+          },
+        output: {
+            path: OUTPUT_DIR,
+            filename: 'two-bundle.js'
+          },
+        plugins: [plugin]
+      }
+    ];
 
     var expected = {
-        one: {
-            js: 'one-bundle.js'
-          },
-        two: {
-            js: 'two-bundle.js'
-          }
-      };
+      one: {
+          js: 'one-bundle.js'
+        },
+      two: {
+          js: 'two-bundle.js'
+        }
+    };
 
     var args = {
-        config: webpackConfig,
-        expected: expected
-      };
+      config: webpackConfig,
+      expected: expected
+    };
 
     expectOutput(args, done);
   });
 
   it('updates output between compiler calls when options.update is true', function (done) {
     var config_1 = {
-        entry: {
-            one: path.join(__dirname, 'fixtures/one.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'one-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp', update: true})]
-      };
+      entry: {
+          one: path.join(__dirname, 'fixtures/one.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'one-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp', update: true})]
+    };
     var config_2 = {
-        entry: {
-            two: path.join(__dirname, 'fixtures/two.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'two-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp', update: true})]
-      };
+      entry: {
+          two: path.join(__dirname, 'fixtures/two.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'two-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp', update: true})]
+    };
 
     var expected = {one: {js: 'one-bundle.js'}, two: {js: 'two-bundle.js'}};
     var args = {config: config_2, expected: expected};
 
     webpack(config_1, function (err, stats) {
-        expect(err).to.be.null;
-        expect(stats.hasErrors()).to.be.false;
-        expectOutput(args, done);
-      });
+      expect(err).to.be.null;
+      expect(stats.hasErrors()).to.be.false;
+      expectOutput(args, done);
+    });
   });
 
   it('overwrites output between compiler calls when options.update is false', function (done) {
     var config_1 = {
-        entry: {
-            one: path.join(__dirname, 'fixtures/one.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'one-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp', update: false})]
-      };
+      entry: {
+          one: path.join(__dirname, 'fixtures/one.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'one-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp', update: false})]
+    };
     var config_2 = {
-        entry: {
-            two: path.join(__dirname, 'fixtures/two.js')
-          },
-        output: {
-            path: OUTPUT_DIR,
-            filename: 'two-bundle.js'
-          },
-        plugins: [new Plugin({path: 'tmp', update: false})]
-      };
+      entry: {
+          two: path.join(__dirname, 'fixtures/two.js')
+        },
+      output: {
+          path: OUTPUT_DIR,
+          filename: 'two-bundle.js'
+        },
+      plugins: [new Plugin({path: 'tmp', update: false})]
+    };
 
     var expected = {two: {js: 'two-bundle.js'}};
     var args = {config: config_2, expected: expected};
 
     webpack(config_1, function (err, stats) {
-        expect(err).to.be.null;
-        expect(stats.hasErrors()).to.be.false;
-        expectOutput(args, done);
-      });
+      expect(err).to.be.null;
+      expect(stats.hasErrors()).to.be.false;
+      expectOutput(args, done);
+    });
   });
 });

--- a/test/pathTemplate.test.js
+++ b/test/pathTemplate.test.js
@@ -10,94 +10,94 @@ describe('parseTemplate', function () {
   describe('parsing', function () {
 
     it('parses the empty string', function () {
-        expect(parseTemplate('').fields).to.eql([
+      expect(parseTemplate('').fields).to.eql([
                 {prefix: '', placeholder: null}
-          ]);
-      });
+        ]);
+    });
 
     it('parses consecutive placeholders', function () {
-        expect(parseTemplate('[id][name][query]').fields).to.eql([
+      expect(parseTemplate('[id][name][query]').fields).to.eql([
                 {prefix: '', placeholder: 'id'},
                 {prefix: '', placeholder: 'name'},
                 {prefix: '', placeholder: 'query'},
                 {prefix: '', placeholder: null}
-          ]);
-      });
+        ]);
+    });
 
     it('parses placeholders and prefixes', function () {
-        expect(parseTemplate('some[id]and[name]then[query]').fields).to.eql([
+      expect(parseTemplate('some[id]and[name]then[query]').fields).to.eql([
                 {prefix: 'some', placeholder: 'id'},
                 {prefix: 'and', placeholder: 'name'},
                 {prefix: 'then', placeholder: 'query'},
                 {prefix: '', placeholder: null}
-          ]);
-      });
+        ]);
+    });
 
     it('handles unknown placeholders', function () {
-        expect(parseTemplate('some[unknown][id]then[hash:pwnd][query]').fields).to.eql([
+      expect(parseTemplate('some[unknown][id]then[hash:pwnd][query]').fields).to.eql([
                 {prefix: 'some[unknown]', placeholder: 'id'},
                 {prefix: 'then[hash:pwnd]', placeholder: 'query'},
                 {prefix: '', placeholder: null}
-          ]);
-      });
+        ]);
+    });
 
     it('handles wierdly formatted placeholders', function () {
-        expect(parseTemplate('some[chunk[id]then[whoops[query]]').fields).to.eql([
+      expect(parseTemplate('some[chunk[id]then[whoops[query]]').fields).to.eql([
                 {prefix: 'some[chunk', placeholder: 'id'},
                 {prefix: 'then[whoops', placeholder: 'query'},
                 {prefix: ']', placeholder: null}
-          ]);
-      });
+        ]);
+    });
 
     it('parses hash width syntax', function () {
-        expect(parseTemplate('[hash:10]and[chunkhash:42]').fields).to.eql([
+      expect(parseTemplate('[hash:10]and[chunkhash:42]').fields).to.eql([
                 {prefix: '', placeholder: 'hash', width: 10},
                 {prefix: 'and', placeholder: 'chunkhash', width: 42},
                 {prefix: '', placeholder: null}
-          ]);
-      });
+        ]);
+    });
 
   });
 
   describe('matching', function () {
 
     it('matches strings without placeholders', function () {
-        var tpl = parseTemplate('foo-bar.jsx');
-        expect(tpl.matches('foo-bar.jsx')).to.eq(true);
-        expect(tpl.matches('foo-bar.css')).to.eq(false);
-      });
+      var tpl = parseTemplate('foo-bar.jsx');
+      expect(tpl.matches('foo-bar.jsx')).to.eq(true);
+      expect(tpl.matches('foo-bar.css')).to.eq(false);
+    });
 
     it('matches strings with [id] placeholder', function () {
-        var tpl = parseTemplate('foo-bar.[id].js');
-        expect(tpl.matches('foo-bar.666.js')).to.eq(true);
-        expect(tpl.matches('foo-bar.nope.js')).to.eq(false);
-      });
+      var tpl = parseTemplate('foo-bar.[id].js');
+      expect(tpl.matches('foo-bar.666.js')).to.eq(true);
+      expect(tpl.matches('foo-bar.nope.js')).to.eq(false);
+    });
 
     it('matches strings with [name] placeholder', function () {
-        var tpl = parseTemplate('[name].js');
-        expect(tpl.matches('foo-bar.chunk.js')).to.eq(true);
-        expect(tpl.matches('foo-bar.chunk.css')).to.eq(false);
-      });
+      var tpl = parseTemplate('[name].js');
+      expect(tpl.matches('foo-bar.chunk.js')).to.eq(true);
+      expect(tpl.matches('foo-bar.chunk.css')).to.eq(false);
+    });
 
     it('matches strings with [query] placeholder', function () {
-        var tpl = parseTemplate('[name].js[query]');
-        expect(tpl.matches('foo-bar.js?anything')).to.eq(true);
+      var tpl = parseTemplate('[name].js[query]');
+      expect(tpl.matches('foo-bar.js?anything')).to.eq(true);
             // query parameter is optional, so this should match too
-        expect(tpl.matches('foo-bar.js')).to.eq(true);
-      });
+      expect(tpl.matches('foo-bar.js')).to.eq(true);
+    });
 
     it('matches strings with [hash] placeholder', function () {
-        var tpl = parseTemplate('[name]_[hash].js');
-        expect(tpl.matches('foo-bar_f00b43.js')).to.eq(true);
-        expect(tpl.matches('foo-bar_w00t.js')).to.eq(false);
-      });
+      var tpl = parseTemplate('[name]_[hash].js');
+      expect(tpl.matches('foo-bar_f00b43.js')).to.eq(true);
+      expect(tpl.matches('foo-bar_w00t.js')).to.eq(false);
+    });
 
     it('matches strings with constrained-width [hash] placeholder', function () {
-        var tpl = parseTemplate('[name]_[hash:6].js');
-        expect(tpl.matches('foo-bar_f00.js')).to.eq(true);
-        expect(tpl.matches('foo-bar_b4d455.js')).to.eq(true);
-        expect(tpl.matches('foo-bar_f00b43b47.js')).to.eq(false);
-      });
+      var tpl = parseTemplate('[name]_[hash:6].js');
+      expect(tpl.matches('foo-bar_f00.js')).to.eq(true);
+      expect(tpl.matches('foo-bar_b4d455.js')).to.eq(true);
+      expect(tpl.matches('foo-bar_f00b43b47.js')).to.eq(false);
+    });
 
   });
 

--- a/test/pathTemplate.test.js
+++ b/test/pathTemplate.test.js
@@ -12,7 +12,7 @@ describe('parseTemplate', function () {
     it('parses the empty string', function () {
       expect(parseTemplate('').fields).to.eql([
                 {prefix: '', placeholder: null}
-        ]);
+      ]);
     });
 
     it('parses consecutive placeholders', function () {
@@ -21,7 +21,7 @@ describe('parseTemplate', function () {
                 {prefix: '', placeholder: 'name'},
                 {prefix: '', placeholder: 'query'},
                 {prefix: '', placeholder: null}
-        ]);
+      ]);
     });
 
     it('parses placeholders and prefixes', function () {
@@ -30,7 +30,7 @@ describe('parseTemplate', function () {
                 {prefix: 'and', placeholder: 'name'},
                 {prefix: 'then', placeholder: 'query'},
                 {prefix: '', placeholder: null}
-        ]);
+      ]);
     });
 
     it('handles unknown placeholders', function () {
@@ -38,7 +38,7 @@ describe('parseTemplate', function () {
                 {prefix: 'some[unknown]', placeholder: 'id'},
                 {prefix: 'then[hash:pwnd]', placeholder: 'query'},
                 {prefix: '', placeholder: null}
-        ]);
+      ]);
     });
 
     it('handles wierdly formatted placeholders', function () {
@@ -46,7 +46,7 @@ describe('parseTemplate', function () {
                 {prefix: 'some[chunk', placeholder: 'id'},
                 {prefix: 'then[whoops', placeholder: 'query'},
                 {prefix: ']', placeholder: null}
-        ]);
+      ]);
     });
 
     it('parses hash width syntax', function () {
@@ -54,7 +54,7 @@ describe('parseTemplate', function () {
                 {prefix: '', placeholder: 'hash', width: 10},
                 {prefix: 'and', placeholder: 'chunkhash', width: 42},
                 {prefix: '', placeholder: null}
-        ]);
+      ]);
     });
 
   });

--- a/test/utils/expectOutput.js
+++ b/test/utils/expectOutput.js
@@ -30,23 +30,23 @@ module.exports = function (outputDir) {
       outputFile = outputFile || 'webpack-assets.json';
 
       webpack(webpackConfig, function (err, stats) {
-          expect(err).to.be.null;
-          expect(stats.hasErrors()).to.be.false;
+        expect(err).to.be.null;
+        expect(stats.hasErrors()).to.be.false;
 
-          var content = fs.readFileSync(path.join(outputDir, outputFile)).toString();
+        var content = fs.readFileSync(path.join(outputDir, outputFile)).toString();
 
-          if (_.isRegExp(expectedResult)) {
-              expect(content).to.match(expectedResult);
-            } else if(_.isString(expectedResult)) {
-                expect(content).to.contain(expectedResult);
-              } else {
+        if (_.isRegExp(expectedResult)) {
+          expect(content).to.match(expectedResult);
+        } else if(_.isString(expectedResult)) {
+          expect(content).to.contain(expectedResult);
+        } else {
                     // JSON object provided
-                var actual = JSON.parse(content);
-                expect(actual).to.eql(expectedResult);
-              }
+          var actual = JSON.parse(content);
+          expect(actual).to.eql(expectedResult);
+        }
 
-          done();
-        });
+        done();
+      });
 
     });
   };

--- a/test/utils/expectOutput.js
+++ b/test/utils/expectOutput.js
@@ -10,14 +10,14 @@ module.exports = function (outputDir) {
 
   return function expectOutput (args, done) {
     if (!args.config) {
-        throw new Error('Expected args.config');
-      }
+      throw new Error('Expected args.config');
+    }
     if (!args.expected) {
-        throw new Error('Expected args.expected');
-      }
+      throw new Error('Expected args.expected');
+    }
     if (!done) {
-        throw new Error('Expected done');
-      }
+      throw new Error('Expected done');
+    }
 
     var webpackConfig = args.config;
     var expectedResult = args.expected;
@@ -25,29 +25,29 @@ module.exports = function (outputDir) {
 
         // Create output folder
     mkdirp(outputDir, function (err) {
-        expect(err).to.be.null;
+      expect(err).to.be.null;
 
-        outputFile = outputFile || 'webpack-assets.json';
+      outputFile = outputFile || 'webpack-assets.json';
 
-        webpack(webpackConfig, function (err, stats) {
-            expect(err).to.be.null;
-            expect(stats.hasErrors()).to.be.false;
+      webpack(webpackConfig, function (err, stats) {
+          expect(err).to.be.null;
+          expect(stats.hasErrors()).to.be.false;
 
-            var content = fs.readFileSync(path.join(outputDir, outputFile)).toString();
+          var content = fs.readFileSync(path.join(outputDir, outputFile)).toString();
 
-            if (_.isRegExp(expectedResult)) {
-                expect(content).to.match(expectedResult);
-              } else if(_.isString(expectedResult)) {
-                  expect(content).to.contain(expectedResult);
-                } else {
+          if (_.isRegExp(expectedResult)) {
+              expect(content).to.match(expectedResult);
+            } else if(_.isString(expectedResult)) {
+                expect(content).to.contain(expectedResult);
+              } else {
                     // JSON object provided
-                  var actual = JSON.parse(content);
-                  expect(actual).to.eql(expectedResult);
-                }
+                var actual = JSON.parse(content);
+                expect(actual).to.eql(expectedResult);
+              }
 
-            done();
-          });
+          done();
+        });
 
-      });
+    });
   };
 };


### PR DESCRIPTION
For some reason the indent changed complete, probably the `eslint --fix`.

But the key idea here is only to get the asset name, in my case, I'm going to serve then thru a CDN.
