### PR TITLE
Normalize path generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var merge = require('lodash.merge');
 
 var getAssetKind = require('./lib/getAssetKind');
@@ -63,7 +64,7 @@ AssetsWebpackPlugin.prototype = {
           }
 
           var typeName = getAssetKind(options, asset);
-          typeMap[typeName] = assetPath + asset;
+          typeMap[typeName] = path.join(assetPath, asset);
 
           return typeMap;
         }, {});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -300,4 +300,26 @@ describe('Plugin', function () {
 
   });
 
+  context('when a trailing slash in the publicPath is missing', function () {
+    it('normalizes publicPath', function (done) {
+      var webpackConfig = {
+        entry: path.join(__dirname, 'fixtures/one.js'),
+        output: {
+          path: OUTPUT_DIR,
+          publicPath: '/bundles',
+          filename: 'index-bundle.js'
+        },
+        plugins: [new Plugin({path: 'tmp'})]
+      };
+
+      var expected = new RegExp('/bundles/index-bundle.js', 'i');
+
+      var args = {
+        config: webpackConfig,
+        expected: expected
+      };
+
+      expectOutput(args, done);
+    });
+  });
 });


### PR DESCRIPTION
Fix a problem when webpack's publicPath option doesn't have the trailing slash.
