### PR TITLE
Allow injecting key value pairs into output

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ function AssetsWebpackPlugin (options) {
     filename: 'webpack-assets.json',
     prettyPrint: false,
     update: false,
-    fullPath: true,
-    inject: {}
+    fullPath: true
   }, options);
   this.writer = createQueuedWriter(createOutputWriter(this.options));
 }
@@ -72,9 +71,9 @@ AssetsWebpackPlugin.prototype = {
         return chunkMap;
       }, {});
 
-      Object.keys(self.options.inject).forEach(function(key) {
-        output[key] = self.options.inject[key];
-      });
+      if (self.options.metadata) {
+        output.metadata = self.options.metadata;
+      }
 
       self.writer(output, function (err) {
         if (err) {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ function AssetsWebpackPlugin (options) {
     filename: 'webpack-assets.json',
     prettyPrint: false,
     update: false,
-    fullPath: true
+    fullPath: true,
+    inject: {}
   }, options);
   this.writer = createQueuedWriter(createOutputWriter(this.options));
 }
@@ -70,6 +71,10 @@ AssetsWebpackPlugin.prototype = {
 
         return chunkMap;
       }, {});
+
+      Object.keys(self.options.inject).forEach(function(key) {
+        output[key] = self.options.inject[key];
+      });
 
       self.writer(output, function (err) {
         if (err) {

--- a/readme.md
+++ b/readme.md
@@ -132,10 +132,15 @@ __update__: When set to true, the output json file will be updated instead of ov
 new AssetsPlugin({update: true})
 ```
 
-__inject__: Inject top level key-value pairs into the output file. Defaults to `{}`.
+__metadata__: Inject metadata into the into the output file. All values will be injected into the key "metadata".
 
 ```js
-new AssetsPlugin({inject: {version: 123}})
+new AssetsPlugin({metadata: {version: 123}})
+
+// Manifest will now contain:
+// {
+//   metadata: {version: 123}
+// }
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,13 @@ __update__: When set to true, the output json file will be updated instead of ov
 new AssetsPlugin({update: true})
 ```
 
+__inject__: Inject top level key-value pairs into the output file. Defaults to `{}`.
+
+```js
+new AssetsPlugin({inject: {version: 123}})
+```
+
+
 ### Using in multi-compiler mode
 
 If you use webpack multi-compiler mode and want your assets written to a single file,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -300,7 +300,7 @@ describe('Plugin', function () {
 
   });
 
-  it('allows injection of arbitrary values', function (done) {
+  it('allows injection of metadata', function (done) {
     var webpackConfig = {
       entry: path.join(__dirname, 'fixtures/one.js'),
       output: {
@@ -309,7 +309,7 @@ describe('Plugin', function () {
       },
       plugins: [new Plugin({
         path: 'tmp',
-        inject: {
+        metadata: {
           foo: 'bar',
           baz: 'buz'
         }
@@ -320,8 +320,10 @@ describe('Plugin', function () {
       main: {
         js: 'index-bundle.js'
       },
-      foo: 'bar',
-      baz: 'buz'
+      metadata: {
+        foo: 'bar',
+        baz: 'buz'
+      }
     };
     expected = JSON.stringify(expected);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -300,4 +300,37 @@ describe('Plugin', function () {
 
   });
 
+  it('allows injection of arbitrary values', function (done) {
+    var webpackConfig = {
+      entry: path.join(__dirname, 'fixtures/one.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index-bundle.js'
+      },
+      plugins: [new Plugin({
+        path: 'tmp',
+        inject: {
+          foo: 'bar',
+          baz: 'buz'
+        }
+      })]
+    };
+
+    var expected = {
+      main: {
+        js: 'index-bundle.js'
+      },
+      foo: 'bar',
+      baz: 'buz'
+    };
+    expected = JSON.stringify(expected);
+
+    var args = {
+      config: webpackConfig,
+      expected: expected
+    };
+
+    expectOutput(args, done);
+  });
+
 });


### PR DESCRIPTION
This allows injecting values into the final manifest file. This is useful for including metadata about the build.
