### PR TITLE
Write to the assets file if there are any differences

### DIFF
--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -41,14 +41,17 @@ module.exports = function (options) {
 
         var assets = merge({}, oldAssets, newAssets);
         var output = options.processOutput(assets);
-
-        fs.writeFile(outputPath, output, function (err) {
-          if (err) {
-            return next(error('Unable to write to ' + outputPath, err));
-          }
-          firstRun = false;
+        if (output !== data) {
+          fs.writeFile(outputPath, output, function (err) {
+            if (err) {
+              return next(error('Unable to write to ' + outputPath, err));
+            }
+            firstRun = false;
+            next();
+          });
+        } else {
           next();
-        });
+        }
       });
     });
   };


### PR DESCRIPTION
In development I don't use any hash appended to the file, so the JSON file with the asset that is generated is very similar and doesn't change much.
Using this approach, I only write to the file if needed.

Since I use symfony to read the assets from the YML file. If the file has a different modification date, he tries to load again the assets, even if they are the same.

**Note: I've fixed the file to pass the tests. The issue was that the write to the file in node was async, so when the test was reading the file, it was empty (since before we always executed the write to the file and executed next when the file was read with success).** 
