### PR TITLE
Update pathTemplate.js

### DIFF
--- a/lib/pathTemplate.js
+++ b/lib/pathTemplate.js
@@ -109,7 +109,7 @@ function parseTemplate (str) {
         fields.push({
           prefix: prefix,
           placeholder: match[1].toLowerCase(),
-          width: parseInt(match[2] || 0, 10)
+          width: ((match[2] || 0, 10) & (match[2] || 0, 10))
         })
         pos += match[0].length
         prefix = ''


### PR DESCRIPTION
This is the fastest ever alternative to parseInt in JS.
https://jsperf.com/rounding-numbers-down