### PR TITLE
Also adds to manifest all assets which are not in a chunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ AssetsWebpackPlugin.prototype = {
       var seenAssets = {}
 
       var chunks = Object.keys(assetsByChunkName)
-      chunks.push("")  // push "unamed" chunk
+      chunks.push('')  // push "unamed" chunk
       var output = chunks.reduce(function (chunkMap, chunkName) {
         var assets = chunkName ? assetsByChunkName[chunkName] : stats.assets
         if (!Array.isArray(assets)) {
@@ -69,7 +69,7 @@ AssetsWebpackPlugin.prototype = {
           typeMap[typeName] = assetPath + asset
 
           added = true
-          seenAssets[asset] = true;
+          seenAssets[asset] = true
           return typeMap
         }, {})
 

--- a/index.js
+++ b/index.js
@@ -49,23 +49,33 @@ AssetsWebpackPlugin.prototype = {
             //     'index-bundle-42b6e1ec4fa8c5f0303e.js.map' ]
             // }
       var assetsByChunkName = stats.assetsByChunkName
+      var seenAssets = {}
 
-      var output = Object.keys(assetsByChunkName).reduce(function (chunkMap, chunkName) {
-        var assets = assetsByChunkName[chunkName]
+      var chunks = Object.keys(assetsByChunkName)
+      chunks.push("")  // push "unamed" chunk
+      var output = chunks.reduce(function (chunkMap, chunkName) {
+        var assets = chunkName ? assetsByChunkName[chunkName] : stats.assets
         if (!Array.isArray(assets)) {
           assets = [assets]
         }
-        chunkMap[chunkName] = assets.reduce(function (typeMap, asset) {
-          if (isHMRUpdate(options, asset) || isSourceMap(options, asset)) {
+        var added = false
+        var typeMap = assets.reduce(function (typeMap, obj) {
+          var asset = obj.name || obj
+          if (isHMRUpdate(options, asset) || isSourceMap(options, asset) || !chunkName && seenAssets[asset]) {
             return typeMap
           }
 
           var typeName = getAssetKind(options, asset)
           typeMap[typeName] = assetPath + asset
 
+          added = true
+          seenAssets[asset] = true;
           return typeMap
         }, {})
 
+        if (added) {
+          chunkMap[chunkName] = typeMap
+        }
         return chunkMap
       }, {})
 


### PR DESCRIPTION
Some times, when loaders or plugins add assets to the bundle (file-loader for example), assets end up without existing in any particular chunk, still they're generated assets. This pull request adds an "empty" chunk in which such assets get added.

Example of a manifest which has assets that are not in any chunk (file-loader adding a png):
```javascript
{
  "main": {
    "js": "main.js",
    "css": "main.css"
  },
  "": {
    "png": "image.png"
  }
}
```