### PR TITLE
Add support for multiple files of the same extension by outputting an array of files

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function AssetsWebpackPlugin (options) {
     prettyPrint: false,
     update: false,
     fullPath: true,
-    arrayOfPaths: false,
+    arrayOfPaths: false
   }, options)
   this.writer = createQueuedWriter(createOutputWriter(this.options))
 }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ AssetsWebpackPlugin.prototype = {
           }
 
           var typeName = getAssetKind(options, asset)
-          typeMap[typeName] = assetPath + asset
+          typeMap[typeName] = typeMap[typeName] || []
+          typeMap[typeName].push(`${assetPath}${asset}`)
 
           return typeMap
         }, {})

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function AssetsWebpackPlugin (options) {
     filename: 'webpack-assets.json',
     prettyPrint: false,
     update: false,
-    fullPath: true
+    fullPath: true,
+    arrayOfPaths: false,
   }, options)
   this.writer = createQueuedWriter(createOutputWriter(this.options))
 }
@@ -61,8 +62,13 @@ AssetsWebpackPlugin.prototype = {
           }
 
           var typeName = getAssetKind(options, asset)
-          typeMap[typeName] = typeMap[typeName] || []
-          typeMap[typeName].push(`${assetPath}${asset}`)
+
+          if (self.options.arrayOfPaths) {
+            typeMap[typeName] = typeMap[typeName] || []
+            typeMap[typeName].push(`${assetPath}${asset}`)
+          } else {
+            typeMap[typeName] = assetPath + asset
+          }
 
           return typeMap
         }, {})


### PR DESCRIPTION
Solves the following two issues: https://github.com/kossnocorp/assets-webpack-plugin/issues/78 https://github.com/kossnocorp/assets-webpack-plugin/issues/72

If `arrayOfPaths` is set to true, it will generate an array of paths. Assuming you are using something like ExtractTextPlugin with multiple outputs of "two.css" and "three.css", it would look like the following:

```
    {
        "app": {
            "js": ["/js/one.bundle.js"],
            "css": ["/js/two.bundle.css", "/js/three.bundle.css"]
        }
    }
```