### PR TITLE
use compiler filesystem

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ AssetsWebpackPlugin.prototype = {
         output.metadata = self.options.metadata
       }
 
+      self.options.path = compiler.outputFileSystem.join(this.outputPath, self.options.path)
       self.writer(compiler.inputFileSystem, compiler.outputFileSystem, output, function (err) {
         if (err) {
           compilation.errors.push(err)

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ AssetsWebpackPlugin.prototype = {
         output.metadata = self.options.metadata
       }
 
-      self.writer(output, function (err) {
+      self.writer(compiler.inputFileSystem, compiler.outputFileSystem, output, function (err) {
         if (err) {
           compilation.errors.push(err)
         }

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -27,7 +27,7 @@ module.exports = function (options) {
         }
         // if options.update is false and we're on first run,
         // start with empty data
-        data = overwrite ? '{}' : data || '{}'
+        data = overwrite ? '{}' : data.toString('utf8') || '{}'
 
         var oldAssets
         try {

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -4,7 +4,6 @@ var merge = require('lodash.merge')
 var error = require('../utils/error')
 
 module.exports = function (options) {
-  var outputPath = path.join(options.path, options.filename)
   var update = options.update
   var firstRun = true
 
@@ -15,6 +14,7 @@ module.exports = function (options) {
   return function writeOutput (ifs, ofs, newAssets, next) {
     // if potions.update is false and we're on the first pass of a (possibly) multicompiler
     var overwrite = !update && firstRun
+    var outputPath = path.join(options.path, options.filename)
 
     ofs.mkdirp(options.path, function (err) {
       if (err) {

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -1,6 +1,4 @@
-var mkdirp = require('mkdirp')
 var path = require('path')
-var fs = require('fs')
 var merge = require('lodash.merge')
 
 var error = require('../utils/error')
@@ -14,15 +12,15 @@ module.exports = function (options) {
     return JSON.stringify(assets, null, options.prettyPrint ? 2 : null)
   }
 
-  return function writeOutput (newAssets, next) {
+  return function writeOutput (ifs, ofs, newAssets, next) {
     // if potions.update is false and we're on the first pass of a (possibly) multicompiler
     var overwrite = !update && firstRun
 
-    mkdirp(options.path, function (err) {
+    ofs.mkdirp(options.path, function (err) {
       if (err) {
         return next(error('Could not create output folder ' + options.path, err))
       }
-      fs.readFile(outputPath, 'utf8', function (err, data) {
+      ifs.readFile(outputPath, function (err, data) {
         // if file does not exist, just write data to it
         if (err && err.code !== 'ENOENT') {
           return next(error('Could not read output file ' + outputPath, err))
@@ -41,7 +39,7 @@ module.exports = function (options) {
         var assets = merge({}, oldAssets, newAssets)
         var output = options.processOutput(assets)
         if (output !== data) {
-          fs.writeFile(outputPath, output, function (err) {
+          ofs.writeFile(outputPath, output, function (err) {
             if (err) {
               return next(error('Unable to write to ' + outputPath, err))
             }

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -27,7 +27,13 @@ module.exports = function (options) {
         }
         // if options.update is false and we're on first run,
         // start with empty data
-        data = overwrite ? '{}' : data.toString('utf8') || '{}'
+        if (overwrite) {
+          data = '{}'
+        } else if (data) {
+          data = data.toString('utf8')
+        } else {
+          data = '{}'
+        }
 
         var oldAssets
         try {

--- a/lib/output/createQueuedWriter.js
+++ b/lib/output/createQueuedWriter.js
@@ -15,18 +15,18 @@ module.exports = function createQueuedWriter (processor) {
 
       var next = queue[0]
       if (next) {
-        processor(next.data, iterator(next.callback))
+        processor(next.ifs, next.ofs, next.data, iterator(next.callback))
       }
     }
   }
 
-  return function queuedWriter (data, callback) {
+  return function queuedWriter (ifs, ofs, data, callback) {
     var empty = !queue.length
-    queue.push({data: data, callback: callback})
+    queue.push({ifs: ifs, ofs: ofs, data: data, callback: callback})
 
     if (empty) {
             // start processing
-      processor(data, iterator(callback))
+      processor(ifs, ofs, data, iterator(callback))
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "css-loader": "^0.9.1",
     "extract-text-webpack-plugin": "^0.3.8",
     "lodash": "^3.9.3",
+    "mkdirp": "^0.5.1",
     "mocha": "^2.2.5",
     "rimraf": "^2.2.8",
     "snazzy": "^3.0.0",
@@ -40,7 +41,6 @@
     "camelcase": "^1.2.1",
     "escape-string-regexp": "^1.0.3",
     "lodash.assign": "^3.2.0",
-    "lodash.merge": "^3.3.2",
-    "mkdirp": "^0.5.1"
+    "lodash.merge": "^3.3.2"
   }
 }


### PR DESCRIPTION
Hi, 

this is a rebased version of
Spotcap/assets-webpack-plugin#compiler-filesystem

the original author didn't put a pull request so I do it now.

my use case is webpack-dev-server where I don't want to have the assets file written to disk but no the memory file system so the dev-server can deliver it.

