### PR TITLE
Use compiler.outputFileSystem for output

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,8 +91,8 @@ AssetsWebpackPlugin.prototype = {
       }
 
       if (!compiler.outputFileSystem.readFile) {
-        compiler.outputFileSystem.readFile = fs.readFile.bind(fs);
-        compiler.outputFileSystem.join = path.join.bind(path);
+        compiler.outputFileSystem.readFile = fs.readFile.bind(fs)
+        compiler.outputFileSystem.join = path.join.bind(path)
       }
 
       self.writer(compiler.outputFileSystem, output, function (err) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var fs = require('fs')
+var path = require('path')
 var merge = require('lodash.merge')
 
 var getAssetKind = require('./lib/getAssetKind')
@@ -88,7 +90,12 @@ AssetsWebpackPlugin.prototype = {
         output.metadata = self.options.metadata
       }
 
-      self.writer(output, function (err) {
+      if (!compiler.outputFileSystem.readFile) {
+        compiler.outputFileSystem.readFile = fs.readFile.bind(fs);
+        compiler.outputFileSystem.join = path.join.bind(path);
+      }
+
+      self.writer(compiler.outputFileSystem, output, function (err) {
         if (err) {
           compilation.errors.push(err)
         }

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -1,12 +1,8 @@
-var mkdirp = require('mkdirp')
-var path = require('path')
-var fs = require('fs')
 var merge = require('lodash.merge')
 
 var error = require('../utils/error')
 
 module.exports = function (options) {
-  var outputPath = path.join(options.path, options.filename)
   var update = options.update
   var firstRun = true
 
@@ -14,14 +10,17 @@ module.exports = function (options) {
     return JSON.stringify(assets, null, options.prettyPrint ? 2 : null)
   }
 
-  return function writeOutput (newAssets, next) {
+  return function writeOutput (fs, newAssets, next) {
     // if potions.update is false and we're on the first pass of a (possibly) multicompiler
     var overwrite = !update && firstRun
 
-    mkdirp(options.path, function (err) {
+    fs.mkdirp(options.path, function (err) {
       if (err) {
         return next(error('Could not create output folder ' + options.path, err))
       }
+
+      var outputPath = fs.join(options.path, options.filename)
+
       fs.readFile(outputPath, 'utf8', function (err, data) {
         // if file does not exist, just write data to it
         if (err && err.code !== 'ENOENT') {

--- a/lib/output/createQueuedWriter.js
+++ b/lib/output/createQueuedWriter.js
@@ -15,18 +15,18 @@ module.exports = function createQueuedWriter (processor) {
 
       var next = queue[0]
       if (next) {
-        processor(next.data, iterator(next.callback))
+        processor(next.fs, next.data, iterator(next.callback))
       }
     }
   }
 
-  return function queuedWriter (data, callback) {
+  return function queuedWriter (fs, data, callback) {
     var empty = !queue.length
-    queue.push({data: data, callback: callback})
+    queue.push({fs: fs, data: data, callback: callback})
 
     if (empty) {
       // start processing
-      processor(data, iterator(callback))
+      processor(fs, data, iterator(callback))
     }
   }
 }


### PR DESCRIPTION
This is so webpack-dev-server (which uses memory-fs) correctly generates the manifest inside the memory file system.