### PR TITLE
Support multi-chunk entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,21 +42,13 @@ AssetsWebpackPlugin.prototype = {
       // publicPath with resolved [hash] placeholder
 
       var assetPath = (stats.publicPath && self.options.fullPath) ? stats.publicPath : ''
-      // assetsByChunkName contains a hash with the bundle names and the produced files
-      // e.g. { one: 'one-bundle.js', two: 'two-bundle.js' }
-      // in some cases (when using a plugin or source maps) it might contain an array of produced files
-      // e.g. {
-      // main:
-      //   [ 'index-bundle-42b6e1ec4fa8c5f0303e.js',
-      //     'index-bundle-42b6e1ec4fa8c5f0303e.js.map' ]
-      // }
-      var assetsByChunkName = stats.assetsByChunkName
+      var entrypoints = stats.entrypoints
       var seenAssets = {}
 
-      var chunks = Object.keys(assetsByChunkName)
+      var chunks = Object.keys(entrypoints)
       chunks.push('')// push "unamed" chunk
       var output = chunks.reduce(function (chunkMap, chunkName) {
-        var assets = chunkName ? assetsByChunkName[chunkName] : stats.assets
+        var assets = chunkName ? entrypoints[chunkName].assets : stats.assets
         if (!Array.isArray(assets)) {
           assets = [assets]
         }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ AssetsWebpackPlugin.prototype = {
 
       var chunks = Object.keys(entries)
       chunks.push('') // push "unamed" chunk
-      var output = chunks.reduce(function(chunkMap, chunkName) {
+      var output = chunks.reduce(function (chunkMap, chunkName) {
         var assets = chunkName
           ? entries[chunkName].assets || entries[chunkName]
           : stats.assets

--- a/index.js
+++ b/index.js
@@ -41,14 +41,17 @@ AssetsWebpackPlugin.prototype = {
       })
       // publicPath with resolved [hash] placeholder
 
-      var assetPath = (stats.publicPath && self.options.fullPath) ? stats.publicPath : ''
-      var entrypoints = stats.entrypoints
+      var assetPath =
+        stats.publicPath && self.options.fullPath ? stats.publicPath : ''
+      var entries = stats.entrypoints || stats.assetsByChunkName
       var seenAssets = {}
 
-      var chunks = Object.keys(entrypoints)
-      chunks.push('')// push "unamed" chunk
-      var output = chunks.reduce(function (chunkMap, chunkName) {
-        var assets = chunkName ? entrypoints[chunkName].assets : stats.assets
+      var chunks = Object.keys(entries)
+      chunks.push('') // push "unamed" chunk
+      var output = chunks.reduce(function(chunkMap, chunkName) {
+        var assets = chunkName
+          ? entries[chunkName].assets || entries[chunkName]
+          : stats.assets
         if (!Array.isArray(assets)) {
           assets = [assets]
         }


### PR DESCRIPTION
Uses `entrypoints` instead of `assetsByChunkName`, which has all the chunks.

This fixes #108 for me, but not sure if it works in webpack <v4