### PR TITLE
Allow webpack 4 entrypoints chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,13 +56,25 @@ AssetsWebpackPlugin.prototype = {
       //   [ 'index-bundle-42b6e1ec4fa8c5f0303e.js',
       //     'index-bundle-42b6e1ec4fa8c5f0303e.js.map' ]
       // }
-      var assetsByChunkName = stats.assetsByChunkName
-      var seenAssets = {}
 
-      var chunks = Object.keys(assetsByChunkName)
-      chunks.push('') // push "unamed" chunk
+      var seenAssets = {}
+      var chunks;
+
+      if(self.options.entrypoints) {
+        chunks = Object.keys(stats.entrypoints);
+      } else {
+        chunks = Object.keys(stats.assetsByChunkName);
+        chunks.push('') // push "unamed" chunk
+      }
+
       var output = chunks.reduce(function (chunkMap, chunkName) {
-        var assets = chunkName ? assetsByChunkName[chunkName] : stats.assets
+        var assets;
+
+        if(self.options.entrypoints) {
+          assets = stats.entrypoints[chunkName].assets;
+        } else {
+          assets = chunkName ? stats.assetsByChunkName[chunkName] : stats.assets
+        }
 
         if (!Array.isArray(assets)) {
           assets = [assets]

--- a/index.js
+++ b/index.js
@@ -58,20 +58,20 @@ AssetsWebpackPlugin.prototype = {
       // }
 
       var seenAssets = {}
-      var chunks;
+      var chunks
 
-      if(self.options.entrypoints) {
-        chunks = Object.keys(stats.entrypoints);
+      if (self.options.entrypoints) {
+        chunks = Object.keys(stats.entrypoints)
       } else {
-        chunks = Object.keys(stats.assetsByChunkName);
+        chunks = Object.keys(stats.assetsByChunkName)
         chunks.push('') // push "unamed" chunk
       }
 
       var output = chunks.reduce(function (chunkMap, chunkName) {
-        var assets;
+        var assets
 
-        if(self.options.entrypoints) {
-          assets = stats.entrypoints[chunkName].assets;
+        if (self.options.entrypoints) {
+          assets = stats.entrypoints[chunkName].assets
         } else {
           assets = chunkName ? stats.assetsByChunkName[chunkName] : stats.assets
         }


### PR DESCRIPTION
Fixes https://github.com/ztoben/assets-webpack-plugin/issues/108

This PR adds an additional option to only return entrypoints as defined by webpack 4. 

If the 'entrypoints' option is given, the output will be limited to the endpoints and the chunks associated with them. eg.

```
const assetsPluginInstance = new AssetsPlugin({ fullPath: false, entrypoints: true })

const config = {
  optimization: {
    runtimeChunk: {
      name: 'runtime'
    },
    splitChunks: {
      chunks: 'all'
    }
  },
  entry: {
    'one': [
      './path/to/one',
    ]
    'two': [
      './path/to/two',
    ]
  }
}
```
Output:
```
{
  "one": {
    "js": [
      "runtime-050efb04221f3362b438.js",
      "vendors~one-two-438aba0b9519e411b3f7.chunk.js",
      "3-836c3b9cad62ddbf5caf.chunk.js",
      "one-0e8c9ee9a21286b55cd0.chunk.js"
    ]
  },
  "two": {
    "js": [
      "runtime-050efb04221f3362b438.js",
      "vendors~one-two-438aba0b9519e411b3f7.chunk.js",
      "4-836c3b9cad62dd3f5caf.chunk.js",
      "two-0e8c9ff9a21286b55cd0.chunk.js"
    ]
  }
}
```

There will be no change to existing functionality if no option is given.

Closes https://github.com/ztoben/assets-webpack-plugin/issues/108