### PR TITLE
Add link to webpack-subresource-integrity package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,7 +264,7 @@ new AssetsPlugin({keepInMemory: true})
 
 Optional. `false` by default.
 
-When set the output from webpack-subresource-integrity is included in the assets file.
+When set the output from [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity) is included in the assets file.
 
 ```js
 new AssetsPlugin({integrity: true})


### PR DESCRIPTION
I went down a bit of a rabbit hole trying to figure out why this wasn't working for me today, it turns out you need to use another plugin to make it work. By making this text a link, it's a little more clear that it depends on another plugin.