### PR TITLE
Set keepInMemory based on webpack-dev-server

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function AssetsWebpackPlugin (options) {
     useCompilerPath: false,
     fileTypes: ['js', 'css'],
     includeAllFileTypes: true,
-    keepInMemory: false,
+    keepInMemory: !!process.argv.find(v => v.includes('webpack-dev-server')),
     integrity: false
   }, options)
   this.writer = createQueuedWriter(createOutputWriter(this.options))


### PR DESCRIPTION
Uses a reasonable default for keepInMemory based on if it's likely that you're running webpack-dev-server. This is technically a backwards compatibility break in the case that you're running webpack dev server and you expect the file to be emitted on the first run and not to be in memory after that. But the common case should be fine.

**Test plan (required)**
Without specifying keepInMemory in the plugin options, running webpack SHOULD set keepInMemory to false.
Running the same webpack config using webpack dev server SHOULD set keepInMemory to true.
User specified keepInMemory SHOULD override this default.

Fixes #171 