### PR TITLE
Add "using this with ASP.NET Core" section.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -354,6 +354,10 @@ And finally in the views:
 </div>
 ```
 
+### Using this with ASP.NET Core
+
+You can use this with ASP.NET Core via the [WebpackTag](https://d.sb/webpacktag) library.
+
 ## Test
 
 ```sh


### PR DESCRIPTION
Links to my [WebpackTag](https://d.sb/webpacktag) library for using assets-webpack-plugin output in an ASP.NET Core app. I didn't create an issue since this is just a doc change.
