### PR TITLE
Upgrade mkdirp to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "camelcase": "5.3.1",
     "escape-string-regexp": "2.0.0",
     "lodash": "4.17.15",
-    "mkdirp": "0.5.2"
+    "mkdirp": "0.5.3"
   },
   "contributors": [
     {


### PR DESCRIPTION
Just after release 0.5.2 with the upgrade of minimist to a patched version mkdirp released 0.5.3, which avoids bundling useless files in the npm package, making the download much smaller.