### PR TITLE
Fix syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fix-lint": "standard --fix",
     "test": "mocha test",
     "build": "babel index.js --out-dir dist && babel lib --out-dir dist/lib",
-    "prepublish": "npm run build",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes a typo from the latest commit, which introduced a syntax error in the package.json file