### PR TITLE
Upgrade mkdirp to 1.0.4 following deprecation prompt

### DIFF
--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -32,11 +32,7 @@ module.exports = function (options) {
     var overwrite = !update && firstRun
     var localFs = options.keepInMemory ? fileStream : fs
 
-    function mkdirpCallback (err) {
-      if (err) {
-        return next(error('Could not create output folder ' + options.path, err))
-      }
-
+    function mkdirpSuccessCallback () {
       var outputPath = options.keepInMemory ? localFs.join(options.path, options.filename)
         : path.join(options.path, options.filename)
 
@@ -72,6 +68,12 @@ module.exports = function (options) {
       })
     }
 
-    options.keepInMemory ? localFs.mkdirp(options.path, mkdirpCallback) : mkdirp(options.path, mkdirpCallback)
+    function mkdirpErrorCallback (err) {
+      next(error('Could not create output folder ' + options.path, err))
+    }
+
+    mkdirp(options.path, { fs: localFs })
+      .then(mkdirpSuccessCallback)
+      .catch(mkdirpErrorCallback)
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "camelcase": "6.0.0",
     "escape-string-regexp": "4.0.0",
     "lodash": "4.17.15",
-    "mkdirp": "0.5.5"
+    "mkdirp": "1.0.4"
   },
   "contributors": [
     {

--- a/test/utils/expectOutput.js
+++ b/test/utils/expectOutput.js
@@ -24,29 +24,33 @@ module.exports = function (outputDir) {
     var outputFile = args.outputFile
 
     // Create output folder
-    mkdirp(outputDir, function (err) {
-      expect(err).to.be.null
-
-      outputFile = outputFile || 'webpack-assets.json'
-
-      webpack(webpackConfig, function (err, stats) {
-        expect(err).to.be.null
-        expect(stats.hasErrors()).to.be.false
-
-        var content = fs.readFileSync(path.join(outputDir, outputFile)).toString()
-
-        if (_.isRegExp(expectedResult)) {
-          expect(content).to.match(expectedResult)
-        } else if (_.isString(expectedResult)) {
-          expect(content).to.contain(expectedResult)
-        } else {
-          // JSON object provided
-          var actual = JSON.parse(content)
-          expect(actual).to.eql(expectedResult)
-        }
-
-        done()
+    mkdirp(outputDir)
+      .then(function () {
+        return null
       })
-    })
+      .then(function (err) {
+        expect(err).to.be.null
+
+        outputFile = outputFile || 'webpack-assets.json'
+
+        webpack(webpackConfig, function (err, stats) {
+          expect(err).to.be.null
+          expect(stats.hasErrors()).to.be.false
+
+          var content = fs.readFileSync(path.join(outputDir, outputFile)).toString()
+
+          if (_.isRegExp(expectedResult)) {
+            expect(content).to.match(expectedResult)
+          } else if (_.isString(expectedResult)) {
+            expect(content).to.contain(expectedResult)
+          } else {
+            // JSON object provided
+            var actual = JSON.parse(content)
+            expect(actual).to.eql(expectedResult)
+          }
+
+          done()
+        })
+      })
   }
 }


### PR DESCRIPTION
Got this warning when installing the package through transitive dependencies:

> Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x.
> (Note that the API surface has changed to use Promises in 1.x.)

Related issue: #226

**Details:**

Updates the version of `mkdirp` package to 1.x branch, namely to the latest 1.0.4. The package API has changed from callback-style to Promise-based, so a small change has to be made in source code as well: `mkdirp` allows `fs` implementation to be [passed as an option](https://www.npmjs.com/package/mkdirp#mkdirpdir-opts---promisestring--undefined), so `localFs` variable can be used directly instead of `options.keepInMemory` ternary.

**Test plan (required)**

```
$ npm run lint
$ npm run test
```

Tests and linting ran without issues.

**Closing issues**

Closes #226 
