### PR TITLE
mkdirp resolved value is an error only when in memory mode

### DIFF
--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -33,7 +33,7 @@ module.exports = function (options) {
     const localFs = options.keepInMemory ? fileStream : fs
 
     function mkdirpCallback (err) {
-      if (err) {
+      if (options.keepInMemory && err) {
         handleMkdirpError(err)
       }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -254,7 +254,7 @@ describe('Plugin', function () {
         filename: 'index-bundle.js'
       },
       plugins: [new Plugin({
-        path: 'tmp',
+        path: 'tmp/nested',
         fullPath: false
       })]
     }


### PR DESCRIPTION
This changes the way we handle the Promise from `mkdirp` when it resolves with a value.
A resolved value should only be treated as an error in memory mode.

Further explanations can be found in the issue.

**Test plan (required)**

I have altered the test `doesn't include full publicPath` to verify the changes. Without the changes to `createOutputWriter.js` this test would now fail.

This also required me to make some changes to `expectOutput.js`. This file used to manually create the output directory, which meant we didn't actually test if `mkdip` was used correctly in `createOutputWriter.js`.

**Closing issues**

closes #251 
