### PR TITLE
Support MJS files

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ AssetsWebpackPlugin.prototype = {
       if (manifestName) {
         const manifestEntry = output[manifestName]
         if (manifestEntry) {
-          let js = manifestEntry.js
+          let js = manifestEntry.js || manifestEntry.mjs
           if (!Array.isArray(js)) {
             js = [js]
           }


### PR DESCRIPTION
Since the agreed upon approach in the area is to use `.mjs` to denotate bundles that support `module` builds, this enables the plugin not to error out on `.mjs` build types
