### PR TITLE
Add note about `includeManifest` in webpack v5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,7 @@ use when you want to inline the manifest in your HTML skeleton for long-term cac
 See [issue #1315](https://github.com/webpack/webpack/issues/1315)
 or [a blog post](https://medium.com/@matt.krick/a-production-ready-realtime-saas-with-webpack-7b11ba2fa5b0#.p1vvfr3bm)
 to learn more.
+**NOTE** for webpack v5, `futureEmitAssets` is defaulted to `false` in development mode.  This option requires `output.futureEmitAssets = true` in order to work.
 
 ```js
 new AssetsPlugin({includeManifest: 'manifest'})


### PR DESCRIPTION
I get an error due to `.source()` being called, similar to https://github.com/gajus/write-file-webpack-plugin/issues/74

