### PR TITLE
Issue #204 Add support for including assets not in any chunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function AssetsWebpackPlugin (options) {
     useCompilerPath: false,
     fileTypes: ['js', 'css'],
     includeAllFileTypes: true,
+    includeFilesWithoutChunk: false,
     keepInMemory: false,
     integrity: false
   }, options)
@@ -66,16 +67,19 @@ AssetsWebpackPlugin.prototype = {
 
       if (self.options.entrypoints) {
         chunks = Object.keys(stats.entrypoints)
+        if (self.options.includeFilesWithoutChunk) {
+          chunks.push('') // push "unnamed" chunk
+        }
       } else {
         chunks = Object.keys(stats.assetsByChunkName)
-        chunks.push('') // push "unamed" chunk
+        chunks.push('') // push "unnamed" chunk
       }
 
       const output = chunks.reduce(function (chunkMap, chunkName) {
         let assets
 
         if (self.options.entrypoints) {
-          assets = stats.entrypoints[chunkName].assets
+          assets = chunkName ? stats.entrypoints[chunkName].assets : stats.assets
         } else {
           assets = chunkName ? stats.assetsByChunkName[chunkName] : stats.assets
         }

--- a/readme.md
+++ b/readme.md
@@ -307,6 +307,16 @@ If the 'entrypoints' option is given, the output will be limited to the entrypoi
 new AssetsPlugin({entrypoints: true})
 ```
 
+#### `includeFilesWithoutChunk`
+
+Optional. `false` by default.
+
+When set and `entrypoints` is set true, will output any files that are part of the unnamed chunk to an additional unnamed ("") entry.
+
+```js
+new AssetsPlugin({includeFilesWithoutChunk: true})
+```
+
 ### Using in multi-compiler mode
 
 If you use webpack multi-compiler mode and want your assets written to a single file,


### PR DESCRIPTION
closes #204 

I just merged the proposed code change shown in the issue.  All tests pass, and the change functions as described for my webpack build (with `entrypoints:true` and files in the empty chunk created by [file-loader](https://webpack.js.org/loaders/file-loader/), an empty chunk is now created in the output file with correct entries).