### PR TITLE
BUGFIX: stats.entrypoints[chunkName].auxiliaryAssets not possible if chunkName is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ AssetsWebpackPlugin.prototype = {
           assets = chunkName ? stats.assetsByChunkName[chunkName] : stats.assets
         }
 
-        if (self.options.includeAuxiliaryAssets && stats.entrypoints[chunkName].auxiliaryAssets) {
+        if (self.options.includeAuxiliaryAssets && chunkName && stats.entrypoints[chunkName].auxiliaryAssets) {
           assets = [...assets, ...stats.entrypoints[chunkName].auxiliaryAssets]
         }
 


### PR DESCRIPTION
chunkName is sometimes empty if 'self.options.includeFilesWithoutChunk' is true.
