### PR TITLE
Fix default path set to '.'

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ function AssetsWebpackPlugin (options) {
     integrity: false,
     removeFullPathAutoPrefix: false
   }, options)
-  this.writer = createQueuedWriter(createOutputWriter(this.options))
 }
 
 AssetsWebpackPlugin.prototype = {
@@ -39,6 +38,7 @@ AssetsWebpackPlugin.prototype = {
         ? (compiler.options.output.path || '.')
         : (self.options.path || '.')
     )
+    self.writer = createQueuedWriter(createOutputWriter(self.options))
 
     const emit = (compilation, callback) => {
       const options = compiler.options


### PR DESCRIPTION
The documentation says the default path is '.', however, without this fix,
by the time createOutputWriter was called, options.path was null and
the attempt to create the output directory would fail.