### PR TITLE
FEATURE: Adding preloaded and prefetched assets

### DIFF
--- a/lib/getDynamicImportedChildAssets.js
+++ b/lib/getDynamicImportedChildAssets.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const getAssetsFromChildChunk = (options, chunk, loadingBehaviour) => {
+  const assets = []
+  if (chunk.assets) {
+    chunk.assets.forEach(asset => {
+      asset.loadingBehaviour = loadingBehaviour
+      assets.push(asset)
+    })
+  }
+  if (options.includeAuxiliaryAssets && chunk.auxiliaryAssets) {
+    chunk.auxiliaryAssets.forEach(asset => {
+      asset.loadingBehaviour = loadingBehaviour
+      assets.push(asset)
+    })
+  }
+  return assets
+}
+
+module.exports = function getDynamicImportedChildAssets (options, children) {
+  let assets = []
+
+  if (children.preload) {
+    children.preload.forEach(childChunk => {
+      const assetsFromChildChunk = getAssetsFromChildChunk(options, childChunk, 'preload')
+      assets = [...assets, ...assetsFromChildChunk]
+    })
+  }
+
+  if (children.prefetch) {
+    children.prefetch.forEach(childChunk => {
+      const assetsFromChildChunk = getAssetsFromChildChunk(options, childChunk, 'prefetch')
+      assets = [...assets, ...assetsFromChildChunk]
+    })
+  }
+
+  return assets
+}

--- a/readme.md
+++ b/readme.md
@@ -65,9 +65,9 @@ The output is a JSON object in the form:
 
 ```json
 {
-    "bundle_name": {
-        "asset_kind": "/public/path/to/asset"
-    }
+  "bundle_name": {
+    "asset_kind": "/public/path/to/asset"
+  }
 }
 ```
 
@@ -365,15 +365,15 @@ When set, will output any files that are part of the chunk and marked as auxilia
 new AssetsPlugin({includeAuxiliaryAssets: true})
 ```
 
-#### `includeLazyChildAssets`
+#### `includeDynamicImportedAssets`
 
 Optional. `false` by default.
 
-When set, will output any files that are dynamically loaded and marked as preloaded or prefechted.
+When set, will output any files that are part of the chunk and marked as preloadable or prefechtable child assets via a dynamic import.
 See: https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules
 
 ```js
-new AssetsPlugin({includeLazyChildAssets: true})
+new AssetsPlugin({includeDynamicImportedAssets: true})
 ```
 
 ### Using in multi-compiler mode

--- a/readme.md
+++ b/readme.md
@@ -365,6 +365,17 @@ When set, will output any files that are part of the chunk and marked as auxilia
 new AssetsPlugin({includeAuxiliaryAssets: true})
 ```
 
+#### `includeLazyChildAssets`
+
+Optional. `false` by default.
+
+When set, will output any files that are dynamically loaded and marked as preloaded or prefechted.
+See: https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules
+
+```js
+new AssetsPlugin({includeLazyChildAssets: true})
+```
+
 ### Using in multi-compiler mode
 
 If you use webpack multi-compiler mode and want your assets written to a single file,


### PR DESCRIPTION
It is possible to dynamically import modules and mark them as prefetched or preloaded assets. See: https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules
This PR recognizes them and adds the corresponding assets with a file type like `js:preload` or  `js:prefetch`.

Another process which consumes the manifest.json can than use this information to handle this files.

Closes #313 