### PR TITLE
feat: add `includeDynamicImportedAssets` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash')
 const getAssetKind = require('./lib/getAssetKind')
 const isHMRUpdate = require('./lib/isHMRUpdate')
 const isSourceMap = require('./lib/isSourceMap')
+const getDynamicImportedChildAssets = require('./lib/getDynamicImportedChildAssets')
 
 const createQueuedWriter = require('./lib/output/createQueuedWriter')
 const createOutputWriter = require('./lib/output/createOutputWriter')
@@ -21,6 +22,7 @@ function AssetsWebpackPlugin (options) {
     includeAllFileTypes: true,
     includeFilesWithoutChunk: false,
     includeAuxiliaryAssets: false,
+    includeDynamicImportedAssets: false,
     keepInMemory: false,
     integrity: false,
     removeFullPathAutoPrefix: false
@@ -97,6 +99,11 @@ AssetsWebpackPlugin.prototype = {
           assets = [...assets, ...stats.entrypoints[chunkName].auxiliaryAssets]
         }
 
+        if (self.options.includeDynamicImportedAssets && chunkName && stats.entrypoints[chunkName].children) {
+          const dynamicImportedChildAssets = getDynamicImportedChildAssets(options, stats.entrypoints[chunkName].children)
+          assets = [...assets, ...dynamicImportedChildAssets]
+        }
+
         if (!Array.isArray(assets)) {
           assets = [assets]
         }
@@ -114,6 +121,7 @@ AssetsWebpackPlugin.prototype = {
             const type = typeof typeMap[typeName]
             const compilationAsset = compilation.assets[asset]
             const integrity = compilationAsset && compilationAsset.integrity
+            const loadingBehaviour = obj.loadingBehaviour
 
             if (type === 'undefined') {
               typeMap[typeName] = combinedPath
@@ -125,7 +133,15 @@ AssetsWebpackPlugin.prototype = {
               if (type === 'string') {
                 typeMap[typeName] = [typeMap[typeName]]
               }
-              typeMap[typeName].push(combinedPath)
+              
+              if (self.options.includeDynamicImportedAssets && loadingBehaviour) {
+                const typeNameWithLoadingBehaviour = typeName + ':' + loadingBehaviour
+                
+                typeMap[typeNameWithLoadingBehaviour] = typeMap[typeNameWithLoadingBehaviour] || []
+                typeMap[typeNameWithLoadingBehaviour].push(combinedPath)
+              } else {
+                typeMap[typeName].push(combinedPath)
+              }
             }
 
             added = true

--- a/index.js
+++ b/index.js
@@ -133,10 +133,10 @@ AssetsWebpackPlugin.prototype = {
               if (type === 'string') {
                 typeMap[typeName] = [typeMap[typeName]]
               }
-              
+
               if (self.options.includeDynamicImportedAssets && loadingBehaviour) {
                 const typeNameWithLoadingBehaviour = typeName + ':' + loadingBehaviour
-                
+
                 typeMap[typeNameWithLoadingBehaviour] = typeMap[typeNameWithLoadingBehaviour] || []
                 typeMap[typeNameWithLoadingBehaviour].push(combinedPath)
               } else {

--- a/lib/getDynamicImportedChildAssets.js
+++ b/lib/getDynamicImportedChildAssets.js
@@ -1,0 +1,34 @@
+const getAssetsFromChildChunk = (options, chunk, loadingBehavior) => {
+  const assets = []
+  
+  if (chunk.assets) {
+    chunk.assets.forEach(asset => {
+      asset.loadingBehavior = loadingBehavior
+      assets.push(asset)
+    })
+  }
+
+  if (options.includeAuxiliaryAssets && chunk.auxiliaryAssets) {
+    chunk.auxiliaryAssets.forEach(asset => {
+      asset.loadingBehavior = loadingBehavior
+      assets.push(asset)
+    })
+  }
+
+  return assets
+}
+
+module.exports = function getDynamicImportedChildAssets (options, children) {
+  const loadingBehaviors = ['preload', 'prefetch']
+  let assets = []
+
+  loadingBehaviors.forEach(loadingBehavior => {
+    if (children[loadingBehavior]) {
+      children[loadingBehavior].forEach(childChunk => {
+        assets = [...assets, ...getAssetsFromChildChunk(options, childChunk, loadingBehavior)]
+      })
+    }
+  })
+
+  return assets
+}

--- a/lib/getDynamicImportedChildAssets.js
+++ b/lib/getDynamicImportedChildAssets.js
@@ -1,6 +1,6 @@
 const getAssetsFromChildChunk = (options, chunk, loadingBehavior) => {
   const assets = []
-  
+
   if (chunk.assets) {
     chunk.assets.forEach(asset => {
       asset.loadingBehavior = loadingBehavior

--- a/readme.md
+++ b/readme.md
@@ -365,6 +365,17 @@ When set, will output any files that are part of the chunk and marked as auxilia
 new AssetsPlugin({includeAuxiliaryAssets: true})
 ```
 
+#### `includeDynamicImportedAssets`
+
+Optional. `false` by default.
+
+When set, will output any files that are part of the chunk and marked as preloadable or prefechtable child assets via a dynamic import.
+See: https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules
+
+```js
+new AssetsPlugin({includeDynamicImportedAssets: true})
+```
+
 ### Using in multi-compiler mode
 
 If you use webpack multi-compiler mode and want your assets written to a single file,


### PR DESCRIPTION
It is possible to dynamically import modules and mark them as prefetched or preloaded assets. See: https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules
This PR recognizes them and adds the corresponding assets with a file type like `js:preload` or  `js:prefetch`.

Another process which consumes the manifest.json can than use this information to handle this files.

Closes #313 