### PR TITLE
fix: the source is not available on afterEmit

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ AssetsWebpackPlugin.prototype = {
     )
     self.writer = createQueuedWriter(createOutputWriter(self.options))
 
-    const afterEmit = (compilation, callback) => {
+    const emitPlugin = (compilation, callback) => {
       const options = compiler.options
       const stats = compilation.getStats().toJson({
         hash: true,
@@ -206,9 +206,9 @@ AssetsWebpackPlugin.prototype = {
     if (compiler.hooks) {
       const plugin = { name: 'AssetsWebpackPlugin' }
 
-      compiler.hooks.afterEmit.tapAsync(plugin, afterEmit)
+      compiler.hooks.emit.tapAsync(plugin, emitPlugin)
     } else {
-      compiler.plugin('after-emit', afterEmit)
+      compiler.plugin('after-emit', emitPlugin)
     }
   }
 }


### PR DESCRIPTION
**Problem:**

Plugin show an error with Webpack 5.

`Error: Content and Map of this Source is not available (only size() is supported)`

**Why?**

Webpack 5 release, replaces the source of assets with SizeOnlySource. 
Official announce => https://webpack.js.org/blog/2020-10-10-webpack-5-release/#sizeonlysource-after-emit

**Key idea:**

Only "emit" called before "AfterEmit" has a source for assets. Use the "emit" hook only if there is hook support. So the old version of the Webpack will continue to use the "afterEmit" hook with the old plugin apply.


Closes #327