### PR TITLE
chore: updated instructions for webpack 4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ npm install assets-webpack-plugin --save-dev
 If you're using Webpack 4 or below:
 
 ```sh
-npm install webpack-assets-manifest@5.1.2 --save-dev
+npm install assets-webpack-plugin@5.1.2 --save-dev
 ```
 
 ## Why Is This Useful?


### PR DESCRIPTION
I think you meant to say `assets-webpack-plugin` (your plugin) instead of `webpack-assets-manifest` (my plugin).