### PR TITLE
feat: respect webpack defaults by using fully initialized compiler object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 tmp
 npm-debug.log*
 .package.json
+.idea
 
 # Lock files shouldn't be committed for libraries https://stackoverflow.com/a/40206145
 yarn.lock

--- a/index.js
+++ b/index.js
@@ -35,12 +35,14 @@ AssetsWebpackPlugin.prototype = {
   apply: function (compiler) {
     const self = this
 
-    self.options.path = path.resolve(
-      self.options.useCompilerPath
-        ? (compiler.options.output.path || '.')
-        : (self.options.path || '.')
-    )
-    self.writer = createQueuedWriter(createOutputWriter(self.options))
+    compiler.hooks.initialize.tap('AssetsWebpackPlugin', () => {
+      self.options.path = path.resolve(
+        self.options.useCompilerPath
+          ? (compiler.options.output.path || '.')
+          : (self.options.path || '.')
+      )
+      self.writer = createQueuedWriter(createOutputWriter(self.options))
+    })
 
     const emitPlugin = (compilation, callback) => {
       const options = compiler.options

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -337,4 +337,35 @@ describe('Plugin', function () {
 
     expectOutput(args, done)
   })
+
+  describe('test compatibility with webpack defaults', function () {
+    const DEFAULT_WEBPACK_OUTPUT_DIR = path.join(__dirname, '../dist')
+    const expectDistOutput = require('./utils/expectOutput')(DEFAULT_WEBPACK_OUTPUT_DIR)
+
+    beforeEach(function (done) {
+      rmRf(DEFAULT_WEBPACK_OUTPUT_DIR, done)
+    })
+
+    it('support useCompilerPath without setting output.path', function (done) {
+      const webpackConfig = {
+        entry: path.join(__dirname, 'fixtures/one.js'),
+        plugins: [new Plugin({
+          useCompilerPath: true
+        })]
+      }
+
+      const expected = {
+        main: {
+          js: 'auto/main.js'
+        }
+      }
+
+      const args = {
+        config: webpackConfig,
+        expected: expected
+      }
+
+      expectDistOutput(args, done)
+    })
+  })
 })


### PR DESCRIPTION
This change helps for cases when `useCompilerPath` option is used, but `output.path` is not defined (since it is optional https://webpack.js.org/migrate/5/?_sm_au_=iVVn83n2sDMW0RFrMjpfkK68cqsfp#clean-up-configuration )

Closes: #403