### PR TITLE
split lodash requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const _ = require('lodash')
+const merge = require('lodash.merge')
 
 const getAssetKind = require('./lib/getAssetKind')
 const isHMRUpdate = require('./lib/isHMRUpdate')
@@ -11,7 +11,7 @@ const createQueuedWriter = require('./lib/output/createQueuedWriter')
 const createOutputWriter = require('./lib/output/createOutputWriter')
 
 function AssetsWebpackPlugin (options) {
-  this.options = _.merge({}, {
+  this.options = merge({}, {
     filename: 'webpack-assets.json',
     prettyPrint: false,
     update: false,

--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const fs = require('fs')
-const _ = require('lodash')
+const merge = require('lodash.merge')
 
 const error = require('../utils/error')
 
@@ -60,7 +60,7 @@ module.exports = function (options) {
           oldAssets = {}
         }
 
-        const assets = orderAssets(_.merge({}, oldAssets, newAssets), options)
+        const assets = orderAssets(merge({}, oldAssets, newAssets), options)
         const output = options.processOutput(assets)
         if (output !== data) {
           localFs.writeFile(outputPath, output, function (err) {

--- a/lib/utils/error.js
+++ b/lib/utils/error.js
@@ -1,7 +1,7 @@
-const _ = require('lodash')
+const assign = require('lodash.assign')
 
 module.exports = function pluginError (message, previousError) {
   const err = new Error('[AssetsWebpackPlugin] ' + message)
 
-  return previousError ? _.assign(err, previousError) : err
+  return previousError ? assign(err, previousError) : err
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
   "dependencies": {
     "camelcase": "^6.0.0",
     "escape-string-regexp": "4.0.0",
-    "lodash": "^4.17.21"
+    "lodash.assign": "^4.2.0",
+    "lodash.isregexp": "^4.0.1",
+    "lodash.isstring": "^4.0.1",
+    "lodash.merge": "^4.6.2"
   },
   "peerDependencies": {
     "webpack": ">=5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assets-webpack-plugin",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Emits a json file with assets paths",
   "main": "dist/index.js",
   "engines": {

--- a/test/utils/expectOutput.js
+++ b/test/utils/expectOutput.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-expressions */
 
-const _ = require('lodash')
+const isRegExp = require('lodash.isregexp')
+const isString = require('lodash.isstring')
+
 const expect = require('chai').expect
 const webpack = require('webpack')
 const fs = require('fs')
@@ -31,9 +33,9 @@ module.exports = function (outputDir) {
 
       const content = fs.readFileSync(path.join(outputDir, outputFile)).toString()
 
-      if (_.isRegExp(expectedResult)) {
+      if (isRegExp(expectedResult)) {
         expect(content).to.match(expectedResult)
-      } else if (_.isString(expectedResult)) {
+      } else if (isString(expectedResult)) {
         expect(content).to.contain(expectedResult)
       } else {
         // JSON object provided


### PR DESCRIPTION
_Please provide enough information so that others can review your pull request:_
Lodash notoriously has many vulnerabilities. Even if these vulnerable parts of lodash aren't used, this will trigger vulnerability tooling such as SonaType. This pull request splits lodash into the four methods that are actually used and prevents having the entirety of lodash as a dependency.

Explain the __details__ for making this change. What existing problem does the pull request solve?
This will prevent `assets-webpack-plugin` from being flagged as a package with critical vulnerabilities.

__Test plan (required)__
Use the plugin as-is, note it still works.

__Closing issues__
closes #459