### PR TITLE
fix: use native mkdirp replacement to address webpack-dev-middleware changes

### DIFF
--- a/lib/output/createOutputWriter.js
+++ b/lib/output/createOutputWriter.js
@@ -81,7 +81,7 @@ module.exports = function (options) {
     }
 
     if (options.keepInMemory) {
-      localFs.mkdirp(options.path, mkdirCallback)
+      localFs.mkdir(options.path, { recursive: true }, mkdirCallback)
     } else {
       fs.mkdir(options.path, { recursive: true }, mkdirCallback)
     }


### PR DESCRIPTION
Fixing `TypeError: localFs.mkdirp is not a function`, caused by the migration from `memfs@3` to `memfs@4` in webpack/webpack-dev-middleware#1693, where `mkdirp` was removed. See: https://github.com/streamich/memfs/releases/tag/v4.2.0

Refs: #441